### PR TITLE
Feature/select model

### DIFF
--- a/example/constants.ts.example
+++ b/example/constants.ts.example
@@ -5,5 +5,9 @@
 
 
 export const defaultCity = {"id":7, "properties":{"name":"Philadelphia","admin":"PA"}};
+export const defaultScenario = 'RCP85';
+export const defaultVariable = 'pr';
+export const defaultYears = 2070;
+
 export const apiHost = "https://staging.api.futurefeelslike.com/api/";
 export const apiToken = "YOUR_API_TOKEN_HERE";

--- a/example/constants.ts.example
+++ b/example/constants.ts.example
@@ -7,7 +7,7 @@
 export const defaultCity = {"id":7, "properties":{"name":"Philadelphia","admin":"PA"}};
 export const defaultScenario = 'RCP85';
 export const defaultVariable = 'pr';
-export const defaultYears = 2070;
+export const defaultYears = '2070';
 
 export const apiHost = "https://staging.api.futurefeelslike.com/api/";
 export const apiToken = "YOUR_API_TOKEN_HERE";

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -17,7 +17,7 @@ import * as $ from 'jquery';
 export class LineGraphComponent {
   public data: ChartData[];
   public extractedData: Array<DataPoint>;
-  public indicator: String;
+  public indicator: string;
   public trendline: Boolean;
   public min: Boolean;
   public max: Boolean;
@@ -33,7 +33,7 @@ export class LineGraphComponent {
   private yScale;                        // D3 scale in Y
   private htmlElement;                   // Host HTMLElement
   private valueline;                     // Base for a chart line
-  private xRange: Array<String>;         // Min, max date range
+  private xRange: Array<string>;         // Min, max date range
   private xData: Array<number>;          // Stores x axis data as integers rather than dates, necessary for trendline math
   private yData: Array<number>;          // Stores just y axis data, multi-use
   private trendData: Array<DataPoint>;   // Formatted data for the trendline

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -11,6 +11,7 @@
           <div class="nav-left">
             <div class="dropdown">
               <i class="icon-globe"></i>
+              <label>City</label>
               <input auto-complete
                 [(ngModel)]="cityModel"
                 placeholder="Enter your city"
@@ -22,6 +23,7 @@
                 [value-changed]="onCitySelected()"
                 min-chars="2" />
             </div>
+            <!-- TODO: change to scenarios model -->
             <div class="dropdown">
               <button class="button dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
@@ -35,10 +37,20 @@
                 <li><a href="#">Separated link</a></li>
               </ul>
             </div>
+            <div>
+              <i class="icon-flash"></i>
+              <label>Models</label>
+              <select multiple name="climateModels" [(ngModel)]="climateModels">
+                <option *ngFor="let climateModel of climateModels" [value]="climateModel">
+                  {{ climateModel.name }}
+                </option>
+              </select>
+            </div>
+            <!--
             <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <button class="button dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
-                All Models
+                {{ climateModel.name }}
                 <i class="icon-angle-down caret"></i>
               </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
@@ -50,6 +62,7 @@
                 <li><a href="#" data-toggle="modal" data-target="#modelOptions">Select Models</a></li>
               </ul>
             </div>
+            -->
           </div>
           <div class="nav-right">
             <button class="button button-default">
@@ -59,7 +72,6 @@
         </nav>
         <charts class="charts scrollable"></charts>
       </div>
-    </div>
   </div>
   <div class="modal modal-small" id="modelOptions" tabindex="-1" role="dialog" aria-labelledby="modelOptions">
     <div class="modal-dialog" role="document">

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -24,22 +24,26 @@
                 min-chars="2" />
             </div>
 
+            <!-- scenario selector -->
             <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <button class="button dropdown-toggle" type="button" id="scenarioDropdown"
+                data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
-                RCP 4.5
+                {{ selectedScenario }}
                 <i class="icon-angle-down caret"></i>
               </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+              <ul class="dropdown-menu" aria-labelledby="scenarioDropdown">
                 <li><a href="#">Action</a></li>
                 <li><a href="#">Another action</a></li>
                 <li><a href="#">Something else here</a></li>
                 <li><a href="#">Separated link</a></li>
               </ul>
             </div>
-            
+
+            <!-- climate model selector -->
             <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" data-target="#modelOptions"data-toggle="modal" aria-haspopup="true" aria-expanded="true">
+              <button class="button dropdown-toggle" type="button" data-target="#modelOptions"
+                data-toggle="modal" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
                 {{ selectedClimateModels }}
                 <label>
@@ -47,6 +51,7 @@
                 </label>
               </button>
             </div>
+
           </div>
           <div class="nav-right">
             <button class="button button-default">

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -43,7 +43,7 @@
               <i class="icon-flash"></i>
               <label>Models</label>
               <select multiple name="climateModels" [(ngModel)]="selectedClimateModels"
-                (change)="onClimateModelChange($event)" class="dropdown form-control">
+                (ngModelChange)="onClimateModelChange($event)" class="dropdown form-control">
                 <option *ngFor="let climateModel of climateModels" [(value)]="climateModel.name">
                   {{ climateModel.name }}
                 </option>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -79,22 +79,10 @@
             <span class="icon icon-cancel"></span>
           </button>
           <h4 class="modal-title">Select Models</h4>
-          <div>
+          <div *ngFor="let climateModel of climateModels">
             <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 1
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 2
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 3
+              <input type="checkbox" name="checkbox" value="value" [(ngModel)]="climateModel.selected">
+              {{ climateModel.name }}
             </label>
           </div>
         </div>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -38,6 +38,7 @@
               </ul>
             </div>
 
+            <!--
             <h2>{{ selectedClimateModels }}</h2>
             <div>
               <i class="icon-flash"></i>
@@ -49,25 +50,17 @@
                 </option>
               </select>
             </div>
-
-            <!--
-            <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <i class="icon-flash"></i>
-                {{ climateModel.name }}
-                <i class="icon-angle-down caret"></i>
-                <label>Models</label>
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-                <li class="active"><a href="#">All Models</a></li>
-                <li><a href="#">Average</a></li>
-                <li><a href="#">1st Quartile</a></li>
-                <li><a href="#">2nd Quartile</a></li>
-                <li><a href="#">3rd Quartile</a></li>
-                <li><a href="#" data-toggle="modal" data-target="#modelOptions">Select Models</a></li>
-              </ul>
-            </div>
             -->
+
+            <div class="dropdown">
+              <button class="button dropdown-toggle" type="button" data-target="#modelOptions"data-toggle="modal" aria-haspopup="true" aria-expanded="true">
+                <i class="icon-flash"></i>
+                {{ selectedClimateModels }}
+                <label>
+                  <a href="#" data-toggle="modal" >Select Models</a>
+                </label>
+              </button>
+            </div>
           </div>
           <div class="nav-right">
             <button class="button button-default">
@@ -104,111 +97,9 @@
               Model 3
             </label>
           </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 4
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 5
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 6
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 7
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 8
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 9
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 10
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 11
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 12
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 13
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 14
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 15
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 16
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 17
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 18
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 19
-            </label>
-          </div>
-          <div>
-            <label>
-              <input type="checkbox" name="checkbox" value="value">
-              Model 20
-            </label>
-          </div>
         </div>
         <div class="modal-footer">
-          <button class="button">Update</button>
+          <button class="button" (click)="updateClimateModels()" data-dismiss="modal">Update</button>
         </div>
       </div>
     </div>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -25,14 +25,15 @@
             </div>
 
             <!-- scenario selector -->
-            <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" id="scenarioDropdown"
-                data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <div dropdown class="dropdown">
+              <button dropdownToggle class="button dropdown-toggle" type="button"
+                id="scenarioDropdown" data-toggle="dropdown" aria-haspopup="true"
+                aria-expanded="true">
                 <i class="icon-flash"></i>
                 {{ selectedScenario }}
                 <i class="icon-angle-down caret"></i>
               </button>
-              <ul class="dropdown-menu" aria-labelledby="scenarioDropdown">
+              <ul dropdownMenu class="dropdown-menu" aria-labelledby="scenarioDropdown">
                 <li *ngFor="let scenario of scenarios">
                   <a href="#" (click)="updateScenario(scenario)">{{ scenario.name }}</a>
                 </li>
@@ -41,12 +42,13 @@
 
             <!-- climate model selector -->
             <div class="dropdown">
-              <button class="button dropdown-toggle" type="button" data-target="#modelOptions"
-                data-toggle="modal" aria-haspopup="true" aria-expanded="true">
+              <button class="button" type="button" data-target="#modelOptions"
+                aria-haspopup="true" aria-expanded="true"
+                (click)="smModal.show()">
                 <i class="icon-flash"></i>
                 {{ selectedClimateModels }}
                 <label>
-                  <a href="#" data-toggle="modal" >Select Models</a>
+                  <a href="#">Select Models</a>
                 </label>
               </button>
             </div>
@@ -61,11 +63,13 @@
         <charts class="charts scrollable"></charts>
       </div>
   </div>
-  <div class="modal modal-small" id="modelOptions" tabindex="-1" role="dialog" aria-labelledby="modelOptions">
-    <div class="modal-dialog" role="document">
+  <div bsModal #smModal="bs-modal" class="modal modal-small" id="modelOptions" tabindex="-1"
+    role="dialog" aria-labelledby="modelOptions" aria-hidden="true" [config]="{backdrop: false}">
+    <div class="modal-dialog modal-sm" role="document">
       <div class="modal-content">
         <div class="modal-body">
-          <button type="button" class="button button-modal-close" data-dismiss="modal" aria-label="Close">
+          <button type="button" class="button button-modal-close" data-dismiss="bs-modal"
+            (click)="updateClimateModels(); smModal.hide()" aria-label="Close">
             <span class="icon icon-cancel"></span>
           </button>
           <h4 class="modal-title">Select Models</h4>
@@ -77,7 +81,7 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button class="button" (click)="updateClimateModels()" data-dismiss="modal">Update</button>
+          <button class="button" (click)="updateClimateModels(); smModal.hide();" data-dismiss="bs-modal">Update</button>
         </div>
       </div>
     </div>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -23,7 +23,7 @@
                 [value-changed]="onCitySelected()"
                 min-chars="2" />
             </div>
-            <!-- TODO: change to scenarios model -->
+
             <div class="dropdown">
               <button class="button dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
@@ -37,21 +37,7 @@
                 <li><a href="#">Separated link</a></li>
               </ul>
             </div>
-
-            <!--
-            <h2>{{ selectedClimateModels }}</h2>
-            <div>
-              <i class="icon-flash"></i>
-              <label>Models</label>
-              <select multiple name="climateModels" [(ngModel)]="selectedClimateModels"
-                (ngModelChange)="onClimateModelChange($event)" class="dropdown form-control">
-                <option *ngFor="let climateModel of climateModels" [(value)]="climateModel.name">
-                  {{ climateModel.name }}
-                </option>
-              </select>
-            </div>
-            -->
-
+            
             <div class="dropdown">
               <button class="button dropdown-toggle" type="button" data-target="#modelOptions"data-toggle="modal" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -33,10 +33,9 @@
                 <i class="icon-angle-down caret"></i>
               </button>
               <ul class="dropdown-menu" aria-labelledby="scenarioDropdown">
-                <li><a href="#">Action</a></li>
-                <li><a href="#">Another action</a></li>
-                <li><a href="#">Something else here</a></li>
-                <li><a href="#">Separated link</a></li>
+                <li *ngFor="let scenario of scenarios">
+                  <a href="#" (click)="updateScenario(scenario)">{{ scenario.name }}</a>
+                </li>
               </ul>
             </div>
 

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -37,21 +37,26 @@
                 <li><a href="#">Separated link</a></li>
               </ul>
             </div>
+
+            <h2>{{ selectedClimateModels }}</h2>
             <div>
               <i class="icon-flash"></i>
               <label>Models</label>
-              <select multiple name="climateModels" [(ngModel)]="climateModels">
-                <option *ngFor="let climateModel of climateModels" [value]="climateModel">
+              <select multiple name="climateModels" [(ngModel)]="selectedClimateModels"
+                (change)="onClimateModelChange($event)" class="dropdown form-control">
+                <option *ngFor="let climateModel of climateModels" [(value)]="climateModel.name">
                   {{ climateModel.name }}
                 </option>
               </select>
             </div>
+
             <!--
             <div class="dropdown">
               <button class="button dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="icon-flash"></i>
                 {{ climateModel.name }}
                 <i class="icon-angle-down caret"></i>
+                <label>Models</label>
               </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
                 <li class="active"><a href="#">All Models</a></li>

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -13,6 +13,8 @@ import { AutoCompleteComponent } from "../auto-complete";
 
 import { apiHost, defaultCity } from "../constants";
 
+import * as _ from 'lodash';
+
 
 @Component({
   selector: 'cc-lab',
@@ -30,8 +32,6 @@ export class LabComponent extends OnInit {
   public apiCities: string = apiHost + "city/?search=:keyword&format=json";
   public cityModel;
   public climateModels: ClimateModel[];
-
-  public selectedClimateModels;
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {
@@ -57,12 +57,14 @@ export class LabComponent extends OnInit {
     };
   }
 
-  public onClimateModelChange(models: String[]) {
-    this.chartService.updateClimateModels(models);
-  }
-
   public updateClimateModels() {
-    console.log('hey!');
+    let models: String[] = this.climateModels.filter(function(model) {
+      return model.selected;
+    }).map(function(model) {
+      return model.name;
+    });
+
+    this.chartService.updateClimateModels(models);
   }
 
   getClimateModels() {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -13,6 +13,8 @@ import { AutoCompleteComponent } from "../auto-complete";
 
 import { apiHost, defaultCity } from "../constants";
 
+import * as _ from 'lodash';
+
 @Component({
   selector: 'cc-lab',
   directives: [NavbarComponent, SidebarComponent, ChartsContainerComponent],
@@ -28,8 +30,21 @@ export class LabComponent extends OnInit {
 
   public apiCities: string = apiHost + "city/?search=:keyword&format=json";
   public cityModel;
-  public selectedClimateModel: ClimateModel;
   public climateModels: ClimateModel[];
+
+  public selectedClimateModels;
+
+  public onClimateModelChange(event: any) {
+    console.log('changed climate model');
+    // selectedClimateModels at this point reports the *last* value, so look at event instead
+    //TODO: something less horrible
+    var selections = '';
+    _.each(event.target.selectedOptions, function(sel) {
+      selections += selections.length ? ',' : '';
+      selections += sel.text
+    });
+    this.chartService.updateClimateModels(selections);
+  }
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -12,6 +12,7 @@ import { AutoCompleteDirective } from "../auto-complete";
 import { AutoCompleteComponent } from "../auto-complete";
 
 import { apiHost, defaultCity, defaultScenario } from "../constants";
+import { NavbarComponent } from '../navbar/navbar.component';
 
 import * as _ from 'lodash';
 
@@ -34,7 +35,7 @@ export class LabComponent extends OnInit {
   public climateModels: ClimateModel[];
 
   public scenarios: Scenario[];
-  public selectedScenario: String;
+  public selectedScenario: string;
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {
@@ -61,7 +62,7 @@ export class LabComponent extends OnInit {
   }
 
   public updateClimateModels() {
-    let models: String[] = this.climateModels.filter(function(model) {
+    let models: string[] = this.climateModels.filter(function(model) {
       return model.selected;
     }).map(function(model) {
       return model.name;

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -5,13 +5,13 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { ChartsContainerComponent } from '../charts/charts-container.component';
-import { ClimateModel } from '../models/chart.models';
+import { ClimateModel, Scenario } from '../models/chart.models';
 import { ChartService } from '../services/chart.service';
 
 import { AutoCompleteDirective } from "../auto-complete";
 import { AutoCompleteComponent } from "../auto-complete";
 
-import { apiHost, defaultCity } from "../constants";
+import { apiHost, defaultCity, defaultScenario } from "../constants";
 
 import * as _ from 'lodash';
 
@@ -32,6 +32,9 @@ export class LabComponent extends OnInit {
   public apiCities: string = apiHost + "city/?search=:keyword&format=json";
   public cityModel;
   public climateModels: ClimateModel[];
+
+  public scenarios: Scenario[];
+  public selectedScenario: String;
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {
@@ -74,8 +77,19 @@ export class LabComponent extends OnInit {
     });
   }
 
+  getScenarios() {
+    this.chartService.loadScenarios();
+    this.chartService.getScenarios().subscribe(data => {
+      this.scenarios = data;
+      console.log('got scenarios:');
+      console.log(this.scenarios);
+    });
+  }
+
   ngOnInit() {
     this.cityModel = this.cityValueFormatter(defaultCity);
+    this.selectedScenario = defaultScenario;
+    this.getScenarios();
     this.getClimateModels();
   }
 }

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -2,7 +2,7 @@
  * Climate Change Lab
  * App Component
  */
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, ViewContainerRef } from '@angular/core';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { ChartsContainerComponent } from '../charts/charts-container.component';
 import { ClimateModel, Scenario } from '../models/chart.models';
@@ -10,6 +10,8 @@ import { ChartService } from '../services/chart.service';
 
 import { AutoCompleteDirective } from "../auto-complete";
 import { AutoCompleteComponent } from "../auto-complete";
+
+import { DROPDOWN_DIRECTIVES, MODAL_DIRECTIVES, BS_VIEW_PROVIDERS } from 'ng2-bootstrap/ng2-bootstrap';
 
 import { apiHost, defaultCity, defaultScenario } from "../constants";
 import { NavbarComponent } from '../navbar/navbar.component';
@@ -19,15 +21,22 @@ import * as _ from 'lodash';
 
 @Component({
   selector: 'cc-lab',
-  directives: [NavbarComponent, SidebarComponent, ChartsContainerComponent],
+  directives: [DROPDOWN_DIRECTIVES, MODAL_DIRECTIVES,
+               NavbarComponent, SidebarComponent, ChartsContainerComponent],
   encapsulation: ViewEncapsulation.None,
-  templateUrl: './lab.component.html'
+  templateUrl: './lab.component.html',
+  viewProviders: [BS_VIEW_PROVIDERS]
 })
 export class LabComponent extends OnInit {
   name = 'Climate Lab';
 
-  constructor(private chartService: ChartService) {
+  constructor(viewContainerRef: ViewContainerRef, private chartService: ChartService) {
     super();
+
+    // TODO: does not work
+    // necessary to catch application root view container ref. see:
+    // https://valor-software.com/ng2-bootstrap/#/modals
+    this.viewContainerRef = viewContainerRef;
   }
 
   public apiCities: string = apiHost + "city/?search=:keyword&format=json";
@@ -36,6 +45,8 @@ export class LabComponent extends OnInit {
 
   public scenarios: Scenario[];
   public selectedScenario: string;
+
+  public viewContainerRef: ViewContainerRef;
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -2,10 +2,10 @@
  * Climate Change Lab
  * App Component
  */
-import { Component, ViewEncapsulation } from '@angular/core';
-import { NavbarComponent } from '../navbar/navbar.component';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { ChartsContainerComponent } from '../charts/charts-container.component';
+import { ClimateModel } from '../models/chart.models';
 import { ChartService } from '../services/chart.service';
 
 import { AutoCompleteDirective } from "../auto-complete";
@@ -19,15 +19,17 @@ import { apiHost, defaultCity } from "../constants";
   encapsulation: ViewEncapsulation.None,
   templateUrl: './lab.component.html'
 })
-export class LabComponent {
+export class LabComponent extends OnInit {
   name = 'Climate Lab';
 
   constructor(private chartService: ChartService) {
-    this.cityModel = this.cityValueFormatter(defaultCity);
+    super();
   }
 
   public apiCities: string = apiHost + "city/?search=:keyword&format=json";
   public cityModel;
+  public selectedClimateModel: ClimateModel;
+  public climateModels: ClimateModel[];
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {
@@ -51,5 +53,17 @@ export class LabComponent {
     return (value) => {
       this.chartService.updateCity(value);
     };
+  }
+
+  getClimateModels() {
+    this.chartService.loadClimateModels();
+    this.chartService.getClimateModels().subscribe(data => {
+      this.climateModels = data;
+    });
+  }
+
+  ngOnInit() {
+    this.cityModel = this.cityValueFormatter(defaultCity);
+    this.getClimateModels();
   }
 }

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -13,7 +13,6 @@ import { AutoCompleteComponent } from "../auto-complete";
 
 import { apiHost, defaultCity } from "../constants";
 
-import * as _ from 'lodash';
 
 @Component({
   selector: 'cc-lab',
@@ -33,18 +32,6 @@ export class LabComponent extends OnInit {
   public climateModels: ClimateModel[];
 
   public selectedClimateModels;
-
-  public onClimateModelChange(event: any) {
-    console.log('changed climate model');
-    // selectedClimateModels at this point reports the *last* value, so look at event instead
-    //TODO: something less horrible
-    var selections = '';
-    _.each(event.target.selectedOptions, function(sel) {
-      selections += selections.length ? ',' : '';
-      selections += sel.text
-    });
-    this.chartService.updateClimateModels(selections);
-  }
 
   // custom formatter to display list of options as City, State
   public cityListFormatter(data: any): string {
@@ -68,6 +55,10 @@ export class LabComponent extends OnInit {
     return (value) => {
       this.chartService.updateCity(value);
     };
+  }
+
+  public onClimateModelChange(models: String[]) {
+    this.chartService.updateClimateModels(models);
   }
 
   getClimateModels() {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -70,6 +70,11 @@ export class LabComponent extends OnInit {
     this.chartService.updateClimateModels(models);
   }
 
+  public updateScenario(scenario: Scenario) {
+    this.selectedScenario = scenario.name;
+    this.chartService.updateScenario(scenario.name);
+  }
+
   getClimateModels() {
     this.chartService.loadClimateModels();
     this.chartService.getClimateModels().subscribe(data => {
@@ -80,9 +85,9 @@ export class LabComponent extends OnInit {
   getScenarios() {
     this.chartService.loadScenarios();
     this.chartService.getScenarios().subscribe(data => {
+      // TODO: it would be nice to populate a tooltip for the scenario list items with their
+      // descriptions once angular2-bootstrap is in place
       this.scenarios = data;
-      console.log('got scenarios:');
-      console.log(this.scenarios);
     });
   }
 

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -61,6 +61,10 @@ export class LabComponent extends OnInit {
     this.chartService.updateClimateModels(models);
   }
 
+  public updateClimateModels() {
+    console.log('hey!');
+  }
+
   getClimateModels() {
     this.chartService.loadClimateModels();
     this.chartService.getClimateModels().subscribe(data => {

--- a/src/app/models/chart.models.ts
+++ b/src/app/models/chart.models.ts
@@ -7,3 +7,7 @@ export class DataPoint {
   date: String;
   value: Number;
 }
+
+export class ClimateModel {
+    name: String;
+}

--- a/src/app/models/chart.models.ts
+++ b/src/app/models/chart.models.ts
@@ -10,4 +10,5 @@ export class DataPoint {
 
 export class ClimateModel {
     name: String;
+    selected: boolean;
 }

--- a/src/app/models/chart.models.ts
+++ b/src/app/models/chart.models.ts
@@ -12,3 +12,8 @@ export class ClimateModel {
     name: String;
     selected: boolean;
 }
+
+export class Scenario {
+    name: String,
+    description: String
+}

--- a/src/app/models/chart.models.ts
+++ b/src/app/models/chart.models.ts
@@ -1,19 +1,19 @@
 export class ChartData {
-  indicator: String;
+  indicator: string;
   data: Array<DataPoint>;
 }
 
 export class DataPoint {
-  date: String;
+  date: string;
   value: Number;
 }
 
 export class ClimateModel {
-    name: String;
+    name: string;
     selected: boolean;
 }
 
 export class Scenario {
-    name: String,
-    description: String
+    name: string;
+    description: string;
 }

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -3,7 +3,7 @@ import {Headers, Http, RequestOptions, Response, URLSearchParams} from '@angular
 import {Observable, Observer} from "rxjs";
 import 'rxjs/Rx';
 
-import { ChartData, ClimateModel } from '../models/chart.models';
+import { ChartData, ClimateModel, Scenario } from '../models/chart.models';
 import { apiHost, apiToken, defaultCity, defaultScenario, defaultVariable, defaultYears } from "../constants";
 
 import * as moment from 'moment';
@@ -33,10 +33,14 @@ export class ChartService {
     private climateModels: Observable<ClimateModel[]>;
     private climateModelObserver: Observer<ClimateModel[]>;
 
+    private scenarios: Observable<Scenario[]>;
+    private scenarioObserver: Observer<Scenario[]>;
+
     constructor(private http: Http) {
         this.chartData = new Observable<ChartData[]>(observer => this.chartDataObserver = observer);
         this.climateModels = new Observable<ClimateModel[]>(observer =>
                                                             this.climateModelObserver = observer);
+        this.scenarios = new Observable<Scenario[]>(observer => this.scenarioObserver = observer);
     }
 
     get() {
@@ -63,6 +67,10 @@ export class ChartService {
 
     getClimateModels(): Observable<ClimateModel[]> {
         return this.climateModels;
+    }
+
+    getScenarios(): Observable<Scenario[]> {
+        return this.scenarios;
     }
 
     loadChartData(): void {
@@ -105,6 +113,21 @@ export class ChartService {
             .map( resp => resp.json())
             .subscribe(resp => {
                 this.climateModelObserver.next(resp || {} as ClimateModel[]);
+            });
+    }
+
+    loadScenarios(): void {
+        let url = apiHost + 'scenario/';
+
+        // append authorization header to request
+        let headers = new Headers({
+            'Authorization': 'Token ' + apiToken
+        });
+        let requestOptions = new RequestOptions({headers: headers});
+        this.http.get(url, requestOptions)
+            .map( resp => resp.json())
+            .subscribe(resp => {
+                this.scenarioObserver.next(resp || {} as Scenario[]);
             });
     }
 
@@ -163,6 +186,11 @@ export class ChartService {
             // default to all by specifying none
             delete this.dataQueryOptions.models;
         }
+        this.loadChartData();
+    }
+
+    public updateScenario(scenario: String): void {
+        this.dataQueryOptions.scenario = scenario;
         this.loadChartData();
     }
 }

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -4,7 +4,7 @@ import {Observable, Observer} from "rxjs";
 import 'rxjs/Rx';
 
 import { ChartData, ClimateModel } from '../models/chart.models';
-import { apiHost, apiToken, defaultCity } from "../constants";
+import { apiHost, apiToken, defaultCity, defaultScenario, defaultVariable, defaultYears } from "../constants";
 
 import * as moment from 'moment';
 import * as _ from 'lodash';
@@ -17,16 +17,15 @@ import * as _ from 'lodash';
 @Injectable()
 export class ChartService {
 
-    // FIXME: using dummy options for API query
-    dataQueryOptions: any = {
+    dataQueryOptions = {
       cityId: defaultCity.id,
-      scenario: 'RCP85',
-      variables: 'pr',
-      years: '2070'
+      scenario: defaultScenario,
+      variables: defaultVariable,
+      years: defaultYears
     };
 
-    // TODO: pretty label
-    chartList = ["pr"];
+    // TODO: pretty label for variable name?
+    chartList = [defaultVariable];
 
     private chartData: Observable<ChartData[]>;
     private chartDataObserver: Observer<ChartData[]>;

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -157,8 +157,13 @@ export class ChartService {
         this.loadChartData();
     }
 
-    public updateClimateModels(models: String): void {
-        this.dataQueryOptions.models = models;
+    public updateClimateModels(models: String[]): void {
+        if (models.length) {
+            this.dataQueryOptions.models = models.join(',');
+        } else if (this.dataQueryOptions.models) {
+            // default to all by specifying none
+            delete this.dataQueryOptions.models;
+        }
         this.loadChartData();
     }
 }

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -78,6 +78,9 @@ export class ChartService {
         searchParams.append('variables', options.variables);
         searchParams.append('years', options.years);
         searchParams.append('format', 'json');
+        if (options.models) {
+            searchParams.append('models', options.models);
+        }
 
         // append authorization header to request
         let headers = new Headers({
@@ -151,6 +154,11 @@ export class ChartService {
 
     public updateCity(city: any): void {
         this.dataQueryOptions.cityId = city.id;
+        this.loadChartData();
+    }
+
+    public updateClimateModels(models: String): void {
+        this.dataQueryOptions.models = models;
         this.loadChartData();
     }
 }

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -19,6 +19,7 @@ export class ChartService {
 
     dataQueryOptions = {
       cityId: defaultCity.id,
+      models: null, // default to all
       scenario: defaultScenario,
       variables: defaultVariable,
       years: defaultYears
@@ -179,17 +180,17 @@ export class ChartService {
         this.loadChartData();
     }
 
-    public updateClimateModels(models: String[]): void {
+    public updateClimateModels(models: string[]): void {
         if (models.length) {
             this.dataQueryOptions.models = models.join(',');
         } else if (this.dataQueryOptions.models) {
             // default to all by specifying none
-            delete this.dataQueryOptions.models;
+            this.dataQueryOptions.models = null;
         }
         this.loadChartData();
     }
 
-    public updateScenario(scenario: String): void {
+    public updateScenario(scenario: string): void {
         this.dataQueryOptions.scenario = scenario;
         this.loadChartData();
     }


### PR DESCRIPTION
Implements two selectors in the navbar, one for changing the scenario, and the other for selecting models. There's not an obvious/easy way to switch back to selecting all models yet. If we move towards using ng2-angular components, I think it might be good to use their multi-select instead of the existing modal of checkboxes from the prototype that I wired up for the model selector here.

This moves the remaining default API query options into the `constants.ts` file, so there are three new constants that will need to be added to run this.

After rebasing off of develop, a number of new typechecker warnings appeared, mostly suggesting using `string` instead of `String`, so I have made those changes (there are no linter warnings now.)