### PR TITLE
Feature/tavg charts

### DIFF
--- a/example/constants.ts.example
+++ b/example/constants.ts.example
@@ -6,8 +6,7 @@
 
 export const defaultCity = {"id":7, "properties":{"name":"Philadelphia","admin":"PA"}};
 export const defaultScenario = 'RCP85';
-export const defaultVariable = 'pr';
-export const defaultYears = '2070';
+export const defaultYears = ["2070","2071","2072","2073","2074","2075","2076"];
 
 export const apiHost = "https://staging.api.futurefeelslike.com/api/";
 export const apiToken = "YOUR_API_TOKEN_HERE";

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -1,6 +1,6 @@
 <div class="chart-heading">
     <h2 class="chart-label">
-    {{indicator}}
+    {{indicator.label}}
     </h2>
     <div class="chart-actions">
         <button class="button button-link" tooltipPlacement="bottom" tooltipTrigger="mouseenter"

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CollapseDirective, TOOLTIP_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 
+import { ChartData } from '../models/chart.models';
+import { ChartService } from '../services/chart.service';
 import { LineGraphComponent } from './line-graph.component';
 
 /*
@@ -14,7 +16,7 @@ import { LineGraphComponent } from './line-graph.component';
   templateUrl: './chart.component.html'
 })
 
-export class ChartComponent {
+export class ChartComponent extends OnInit {
 
     private isCollapsed: boolean;
     private trendline: boolean;
@@ -22,6 +24,7 @@ export class ChartComponent {
     private max: boolean;
     private minVal: number;
     private maxVal: number;
+    private chartData: ChartData[];
 
     toggleTrendline () {
         this.trendline = !this.trendline;
@@ -35,7 +38,20 @@ export class ChartComponent {
         this.max = !this.max;
     }
 
-    constructor () {
+    makeChart() {
+      this.chartService.loadChartData();
+      this.chartService.getChartData().subscribe(data=> {
+        this.chartData = data;
+      });
+      console.log(this.chartData);
+    }
+
+    ngOnInit() {
+        this.makeChart();
+    }
+
+    constructor(private chartService: ChartService) {
+        super();
         this.isCollapsed = false;
         this.trendline = false;
         this.min = false;

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CollapseDirective, TOOLTIP_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 
 import { ChartData } from '../models/chart.models';
+import { Indicator } from '../models/indicator.models';
 import { ChartService } from '../services/chart.service';
 import { LineGraphComponent } from './line-graph.component';
 
@@ -18,13 +19,13 @@ import { LineGraphComponent } from './line-graph.component';
 
 export class ChartComponent extends OnInit {
 
+    private indicator: Indicator;
     private isCollapsed: boolean;
     private trendline: boolean;
     private min: boolean;
     private max: boolean;
     private minVal: number;
     private maxVal: number;
-    private chartData: ChartData[];
 
     toggleTrendline () {
         this.trendline = !this.trendline;
@@ -38,16 +39,7 @@ export class ChartComponent extends OnInit {
         this.max = !this.max;
     }
 
-    makeChart() {
-      this.chartService.loadChartData();
-      this.chartService.getChartData().subscribe(data=> {
-        this.chartData = data;
-      });
-      console.log(this.chartData);
-    }
-
     ngOnInit() {
-        this.makeChart();
     }
 
     constructor(private chartService: ChartService) {

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -1,9 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { CollapseDirective, TOOLTIP_DIRECTIVES } from 'ng2-bootstrap/ng2-bootstrap';
 
-import { ChartData } from '../models/chart.models';
 import { Indicator } from '../models/indicator.models';
-import { ChartService } from '../services/chart.service';
 import { LineGraphComponent } from './line-graph.component';
 
 /*
@@ -17,7 +15,7 @@ import { LineGraphComponent } from './line-graph.component';
   templateUrl: './chart.component.html'
 })
 
-export class ChartComponent extends OnInit {
+export class ChartComponent {
 
     private indicator: Indicator;
     private isCollapsed: boolean;
@@ -39,11 +37,7 @@ export class ChartComponent extends OnInit {
         this.max = !this.max;
     }
 
-    ngOnInit() {
-    }
-
-    constructor(private chartService: ChartService) {
-        super();
+    constructor() {
         this.isCollapsed = false;
         this.trendline = false;
         this.min = false;

--- a/src/app/charts/charts-container.component.ts
+++ b/src/app/charts/charts-container.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { ChartData } from '../models/chart.models';
 import { ChartService } from '../services/chart.service';
 import { ChartComponent } from './chart.component';
 
@@ -12,27 +11,18 @@ import { ChartComponent } from './chart.component';
   selector: 'charts',
   directives: [ChartComponent],
   template: `<div class="chart" *ngFor="let chart of chartList">
-                <chart [indicator]="chart" [chartData]="chartData"></chart>
+                <chart [indicator]="chart"></chart>
             </div>`
 })
 export class ChartsContainerComponent extends OnInit {
     private chartList: Array<String>;
-    private chartData: ChartData[];
 
     constructor(private chartService: ChartService) {
       super();
     }
 
-    makeCharts() {
-      this.chartService.loadChartData();
-      this.chartService.getChartData().subscribe(data=> {
-        this.chartData = data;
-      });
-    }
-
     ngOnInit() {
       // First, subscribe to chartList observable
       this.chartList = this.chartService.get();
-      this.makeCharts();
     }
 }

--- a/src/app/charts/charts-container.component.ts
+++ b/src/app/charts/charts-container.component.ts
@@ -11,18 +11,27 @@ import { ChartComponent } from './chart.component';
   selector: 'charts',
   directives: [ChartComponent],
   template: `<div class="chart" *ngFor="let chart of chartList">
-                <chart [indicator]="chart"></chart>
+                <chart [indicator]="chart" [chartData]="chartData"></chart>
             </div>`
 })
 export class ChartsContainerComponent extends OnInit {
     private chartList: Array<String>;
+    private chartData;
 
     constructor(private chartService: ChartService) {
       super();
     }
 
+    makeCharts() {
+      this.chartService.loadChartData();
+      this.chartService.getChartData().subscribe(data=> {
+        this.chartData = data;
+      });
+    }
+
     ngOnInit() {
       // First, subscribe to chartList observable
       this.chartList = this.chartService.get();
+      this.makeCharts();
     }
 }

--- a/src/app/charts/charts-container.component.ts
+++ b/src/app/charts/charts-container.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
+import { ChartData } from '../models/chart.models';
 import { ChartService } from '../services/chart.service';
 import { ChartComponent } from './chart.component';
 
@@ -16,7 +17,7 @@ import { ChartComponent } from './chart.component';
 })
 export class ChartsContainerComponent extends OnInit {
     private chartList: Array<String>;
-    private chartData;
+    private chartData: Array<ChartData>;
 
     constructor(private chartService: ChartService) {
       super();

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -102,7 +102,7 @@ export class LineGraphComponent {
         this.xRange = D3.extent(this.extractedData, d => d.date);
         this.xScale.domain(this.xRange);
         // Adjust y scale, prettify graph
-        let yPad = Math.abs((D3.max(this.yData) - D3.min(this.yData)) * 2/3);
+        const yPad = Math.abs((D3.max(this.yData) - D3.min(this.yData)) * 2/3);
         this.yScale.domain([D3.min(this.yData) - yPad, D3.max(this.yData) + yPad]);
     }
 

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -63,11 +63,11 @@ export class LineGraphComponent {
     }
 
     private filterData(): void {
-        let indicator = this.indicator;
+        let indicator = this.indicator.name;
         // Preserves parent data by fresh copying indicator data that will undergo processing
         this.extractedData = _.cloneDeep(_.find(this.data, obj => obj['indicator'] === indicator));
         _.has(this.extractedData, 'data') ? this.extractedData = this.extractedData['data'] : this.extractedData = [];
-        // Remove empty day in non-leap years
+        // Remove empty day in non-leap years (affects only daily data)
         if (this.extractedData[365] && this.extractedData[365]['date'] == null) {
             this.extractedData.pop();
         }
@@ -96,11 +96,12 @@ export class LineGraphComponent {
 
     // Set axis scales
     private setAxisScales(): void {
-        var parseTime = D3.timeParse('%Y-%m-%d');
+        // Time scales only recognize annual and daily data
+        var parseTime = this.time === "annual"? D3.timeParse('%Y') : D3.timeParse('%Y-%m-%d');
         this.extractedData.forEach(d => d.date = parseTime(d.date));
         this.xRange = D3.extent(this.extractedData, d => d.date);
         this.xScale.domain(this.xRange);
-        this.yScale.domain([0, D3.max(this.yData)]);
+        this.yScale.domain([D3.min(this.yData) - 10, D3.max(this.yData) + 10]);
     }
 
     /* Will draw the X Axis */

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -101,7 +101,9 @@ export class LineGraphComponent {
         this.extractedData.forEach(d => d.date = parseTime(d.date));
         this.xRange = D3.extent(this.extractedData, d => d.date);
         this.xScale.domain(this.xRange);
-        this.yScale.domain([D3.min(this.yData) - 5, D3.max(this.yData) + 5]);
+        // Adjust y scale, prettify graph
+        let yPad = Math.abs((D3.max(this.yData) - D3.min(this.yData)) * 2/3);
+        this.yScale.domain([D3.min(this.yData) - yPad, D3.max(this.yData) + yPad]);
     }
 
     /* Will draw the X Axis */
@@ -142,7 +144,7 @@ export class LineGraphComponent {
             var y1 = leastSquaresCoeff[0] + leastSquaresCoeff[1];
             var x2 = this.xRange[0];
             var y2 = leastSquaresCoeff[0] * this.xData.length + leastSquaresCoeff[1];
-            this.trendData = [{'date': x1, 'value': y1}, {'date': x2, 'value': y2}];
+            this.trendData = [{'date': x1, 'value': y2}, {'date': x2, 'value': y1}];
             // Add trendline
             this.drawLine(this.trendData, 'trendline');
         }

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -65,7 +65,7 @@ export class LineGraphComponent {
 
     private filterData(): void {
         // Preserves parent data by fresh copying indicator data that will undergo processing
-        this.extractedData = _.cloneDeep(_.find(this.data, obj => obj['indicator']['name'] === this.indicator.name));
+        this.extractedData = _.cloneDeep(_.find(this.data, obj => obj.indicator.name === this.indicator.name));
         _.has(this.extractedData, 'data') ? this.extractedData = this.extractedData['data'] : this.extractedData = [];
         // Remove empty day in non-leap years (affects only daily data)
         if (this.extractedData[365] && this.extractedData[365]['date'] == null) {

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -102,7 +102,7 @@ export class LineGraphComponent {
         this.xRange = D3.extent(this.extractedData, d => d.date);
         this.xScale.domain(this.xRange);
         // Adjust y scale, prettify graph
-        const yPad = Math.abs((D3.max(this.yData) - D3.min(this.yData)) * 2/3);
+        const yPad = ((D3.max(this.yData) - D3.min(this.yData)) > 0) ? ((D3.max(this.yData) - D3.min(this.yData)) * 2/3) : 5;
         this.yScale.domain([D3.min(this.yData) - yPad, D3.max(this.yData) + yPad]);
     }
 

--- a/src/app/models/chart.models.ts
+++ b/src/app/models/chart.models.ts
@@ -1,6 +1,7 @@
 export class ChartData {
   indicator: string;
   data: Array<DataPoint>;
+  time_agg: Array<String>;
 }
 
 export class DataPoint {

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -92,7 +92,7 @@ export class ChartService {
         });
         let requestOptions = new RequestOptions({headers: headers, search: searchParams});
 
-        // Set up query for each indicator
+        // Collect a query for each indicator
         _.each(this.chartList, indic => {
             options.indicator = indic.name;
             // query like:
@@ -101,6 +101,7 @@ export class ChartService {
             queries.push(this.http.get(url, requestOptions).map( resp => resp.json()));
         });
 
+        // Multi-observable that updates subscribers only after all queries return
         Observable.forkJoin(queries).subscribe(resp => {
             this.chartDataObserver.next(this.convertChartData(resp || {}));
         });

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -168,7 +168,8 @@ export class ChartService {
                 indicators.push(indicator);
                 chartData.push({
                     'indicator': indicator,
-                    'data': indicatorData
+                    'data': indicatorData,
+                    'time_agg': indicator.label.match(/Daily/) || indicator.label.match(/Yearly/)
                 } as ChartData);
             }
         });

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -4,7 +4,7 @@ import {Observable, Observer} from "rxjs";
 import 'rxjs/Rx';
 
 import { ChartData, ClimateModel, Scenario } from '../models/chart.models';
-import { apiHost, apiToken, defaultCity, defaultScenario, defaultVariable, defaultYears } from "../constants";
+import { apiHost, apiToken, defaultCity, defaultScenario, defaultVariable, defaultIndicator, defaultYears } from "../constants";
 
 import * as moment from 'moment';
 import * as _ from 'lodash';
@@ -21,6 +21,7 @@ export class ChartService {
       cityId: defaultCity.id,
       models: null, // default to all
       scenario: defaultScenario,
+      indicator: defaultIndicator,
       variables: defaultVariable,
       years: defaultYears
     };
@@ -83,7 +84,11 @@ export class ChartService {
         let url = apiHost + 'climate-data/' + options.cityId + '/' + options.scenario + '/';
 
         let searchParams: URLSearchParams = new URLSearchParams();
-        searchParams.append('variables', options.variables);
+        if (options.indicator) {
+            url += 'indicator/' + options.indicator + '/';
+        } else if (options.variables) {
+            searchParams.append('variables', options.variables);
+        }
         searchParams.append('years', options.years);
         searchParams.append('format', 'json');
         if (options.models) {

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -172,33 +172,6 @@ export class ChartService {
                 } as ChartData);
             }
         });
-
-        /* For daily value conversions
-
-        _.each(_.keys(data), (key) => {
-            let days: string[] = this.getDaysInYear(key);
-            _.each(_.keys(data[key]), function(indicator) {
-                // make array of [date, value] pairs with zip, then convert to keyed object
-                var indicatorData = _.map(_.zip(days, data[key][indicator]), function(arr) {
-                    return {
-                        'date': arr[0],
-                        'value': arr[1]
-                    };
-                });
-
-                if (!_.includes(indicators, indicator)) {
-                    indicators.push(indicator);
-                    chartData.push({
-                        'indicator': indicator,
-                        'data': indicatorData
-                    } as ChartData);
-                } else {
-                    // have multiple years; append to existing indicator data
-                    chartData[indicator]['data'].push(indicatorData);
-                }
-            });
-        }); */
-
         return chartData;
     }
 

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -27,7 +27,7 @@ export class SidebarComponent extends OnInit {
     // Set up click event handlers
     onIndicatorClicked(indicator) {
       // TODO: once indicator in place for raw data queries, change to pass Indicator object
-      this.chartService.addChart(indicator.variables[0]);
+      this.chartService.addChart(indicator);
     }
 
     ngOnInit() {


### PR DESCRIPTION
## Overview

Pull graph data from indicators endpoint (only Annual T min and T max right now).

### Demo
![screen shot 2016-09-06 at 10 01 17 am](https://cloud.githubusercontent.com/assets/10568752/18276857/7f2db716-741a-11e6-9c5f-a078c3dbd8fa.png)

### Notes

I equivocated about where it was sensible to query but settled back at the chart container. This is because re-querying (i.e changing model, scenario, city) will need to happen to all active graphs and I felt it was better organized and time-sensible (multiquery observable) even though we pass around more data. I left but commented out prior code to handle daily data because we will need it soon.

The one linter error is because URLSearchParams doesn't want an array even if it accepts them just fine.

## Testing Instructions

Nothing special. Note, if you select RCP45 stuff blanks out in some cases because there is no data.

