### PR TITLE
Resize graphs on window width change

### DIFF
--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ElementRef } from '@angular/core';
+import { Component, ViewEncapsulation, ElementRef, HostListener } from '@angular/core';
 import { ChartData, DataPoint } from '../models/chart.models';
 import { Indicator } from '../models/indicator.models';
 import * as D3 from 'd3';
@@ -53,6 +53,11 @@ export class LineGraphComponent {
           'Yearly': '%Y',
           'Daily': '%Y-%m-%d'
         }
+    }
+
+    @HostListener('window:resize', ['$event'])
+    onResize(event) {
+      this.ngOnChanges();
     }
 
     /* Will Update on every @Input change */


### PR DESCRIPTION
Fixes #40 

The listener is set up in the charts container so that we only have 1 listener. It seemed a cleaner idea than attaching a listener to every chart component or graph even if it means passing around another input variable another layer.