### PR TITLE
Feature/vagrant build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ node_modules/
 
 coverage/
 dist/
+
+# Vagrant
+.vagrant/
+ansible/*.retry
+ansible/roles/azavea.*
+

--- a/README.md
+++ b/README.md
@@ -6,12 +6,36 @@
 
 Requires node.js 6.2.0+ and npm 3.8+ for angular compatibility.
 
+Alternatively, you can bring up the vagrant VM that has the dependencies installed.
+
 ### Setup
 
   - Clone this repo and run `npm install`
   - `cp example/constants.ts.example src/app/constants.ts`
   - Edit `constants.ts` to set the API server name and API key
 
+To use the vagrant machine, first start it with:
+```bash
+vagrant up
+```
+
+Then to start the development server within the VM:
+
+```bash
+vagrant ssh
+cd /opt/climate-change-lab
+npm start
+```
+
+The site will then be available at [http://localhost:3100](http://localhost:3100) on your host machine.
+
+Note that if you are using a Mac host, it may be necessary to run:
+
+```
+npm rebuild node-sass
+```
+
+to switch between using the VM build and building directly on your host machine.
 
 ### Getting started
 
@@ -21,9 +45,9 @@ Requires node.js 6.2.0+ and npm 3.8+ for angular compatibility.
 | `npm run server:dev` | Serve project normally, without hot module replacement | If you don't want hot module replacement |
 | `npm run lint --silent` | Run typescript linter | To clean up your angular and .ts files |
 
-Navigate to http://localhost:3100 in your browser
+Navigate to [http://localhost:3100](http://localhost:3100) in your browser.
 
-Additional commands available in package.json
+Additional commands available in package.json.
 
 ### Tech Stack
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.6"
+
+# Deserialize Ansible Galaxy installation metadata for a role
+def galaxy_install_info(role_name)
+  role_path = File.join("deployment", "ansible", "roles", role_name)
+  galaxy_install_info = File.join(role_path, "meta", ".galaxy_install_info")
+
+  if (File.directory?(role_path) || File.symlink?(role_path)) && File.exists?(galaxy_install_info)
+    YAML.load_file(galaxy_install_info)
+  else
+    { install_date: "", version: "0.0.0" }
+  end
+end
+
+# Uses the contents of roles.yml to ensure that ansible-galaxy is run
+# if any dependencies are missing
+def install_dependent_roles
+  ansible_roles_spec = File.join("ansible", "roles.yml")
+
+  YAML.load_file(ansible_roles_spec).each do |role|
+    role_name = role["src"]
+    role_version = role["version"]
+    role_path = File.join("ansible", "roles", role_name)
+    galaxy_metadata = galaxy_install_info(role_name)
+
+    if galaxy_metadata["version"] != role_version.strip
+      unless system("ansible-galaxy install -f -r #{ansible_roles_spec} -p #{File.dirname(role_path)}")
+        $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
+        exit(1)
+      end
+
+      break
+    end
+  end
+end
+
+# Install missing role dependencies based on the contents of roles.yml
+if [ "up", "provision" ].include?(ARGV.first)
+  install_dependent_roles
+end
+
+ANSIBLE_ENV_GROUPS = {
+  "development:children" => [
+    "climate-change-lab-servers"
+  ]
+}
+VAGRANT_NETWORK_OPTIONS = { auto_correct: false }
+
+ANSIBLE_GROUPS = {
+  "climate-change-lab-servers-servers" => [ "app" ]
+}
+
+MOUNT_OPTIONS = if Vagrant::Util::Platform.linux? then
+                  ['rw', 'vers=4', 'tcp', 'nolock']
+                else
+                  ['vers=3', 'udp']
+                end
+
+ROOT_VM_DIR = "/opt/climate-change-lab"
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define "app" do |app|
+    app.vm.box = "ubuntu/precise64"
+    app.vm.hostname = "app"
+    app.vm.network "private_network", ip: ENV.fetch("CLIMATE_CHANGE_PRIVATE_IP", "192.168.8.111")
+
+    app.vm.synced_folder '.', ROOT_VM_DIR, type: "nfs", mount_options: MOUNT_OPTIONS
+
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible/climate-change-lab.yml"
+      ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
+      ansible.raw_arguments = ["--timeout=60"]
+    end
+
+    app.ssh.forward_x11 = true
+
+    app.vm.provider :virtualbox do |v|
+      v.memory = ENV.fetch("CLIMATE_CHANGE_LAB_MEM", 1024)
+      v.cpus = ENV.fetch("CLIMATE_CHANGE_LAB_CPUS", 2)
+    end
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,6 +76,7 @@ Vagrant.configure("2") do |config|
       ansible.raw_arguments = ["--timeout=60"]
     end
 
+    app.vm.network "forwarded_port", guest: 3100, host: 3100
     app.ssh.forward_x11 = true
 
     app.vm.provider :virtualbox do |v|

--- a/ansible/climate-change-lab.yml
+++ b/ansible/climate-change-lab.yml
@@ -1,0 +1,11 @@
+---
+- hosts: app
+  become: true
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
+  roles:
+    - { role: "azavea.nodejs" }
+    - { role: "climate-change-lab.app" }

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,0 +1,2 @@
+nodejs_version: 6.5.0
+nodejs_npm_version: 3.10.3

--- a/ansible/roles.yml
+++ b/ansible/roles.yml
@@ -1,0 +1,2 @@
+- src: azavea.nodejs
+  version: 0.4.0

--- a/ansible/roles/climate-change-lab.app/defaults/main.yml
+++ b/ansible/roles/climate-change-lab.app/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+  root_dir: /opt
+  app_dir: "{{ root_dir }}/climate-change-lab"

--- a/ansible/roles/climate-change-lab.app/tasks/main.yml
+++ b/ansible/roles/climate-change-lab.app/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+  - name: "Install node dependencies"
+    npm: path={{ app_dir }}
+    become_user: "{{ ansible_ssh_user }}"
+
+  # necessary for Mac hosts
+  - name "Rebuild SASS"
+    command: "npm rebuild node-sass"
+    become_user: "{{ ansible_ssh_user }}"
+
+  - name: "Production build"
+    command: "npm run build:prod"
+    args:
+      chdir: "{{ app_dir }}"
+    become_user: "{{ ansible_ssh_user }}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lab",
     "Azavea"
   ],
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "scripts": {
     "tslint": "tslint",
     "webpack": "webpack",


### PR DESCRIPTION
Add configuration to optionally build project within vagrant, to be used for testing on Jenkins.

`vagrant up` brings up a VM with the project mounted at `/opt/climate-change-lab` and runs `npm install`.
