### PR TITLE
Show only yearly indicators in sidebar

### DIFF
--- a/src/app/models/indicator.models.ts
+++ b/src/app/models/indicator.models.ts
@@ -2,5 +2,6 @@ export class Indicator {
     name: string;
     label: string;
     description: string;
+    time_aggregation: string;
     variables: string[];
 }

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,7 +1,7 @@
 <div class="sidebar-content scrollable">
     <h2 class="sidebar-title">Indicators</h2>
-    <h3 class="sidebar-category">All Indicators</h3>
-    <button class="indicator" *ngFor="let indicator of indicators"
+    <h3 class="sidebar-category">Yearly Indicators</h3>
+    <button class="indicator" *ngFor="let indicator of yearlyIndicators"
         (click)="onIndicatorClicked(indicator)"
         tooltip="{{ indicator.description }}"
         tooltipPlacement="right"

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -15,7 +15,7 @@ import { Indicator } from '../models/indicator.models';
   templateUrl: './sidebar.component.html'
 })
 export class SidebarComponent extends OnInit {
-    private indicators: Indicator[];
+    private yearlyIndicators: Indicator[];
 
     constructor(private chartService: ChartService, private indicatorsService: IndicatorsService) {
       super();
@@ -29,7 +29,8 @@ export class SidebarComponent extends OnInit {
 
     ngOnInit() {
       this.indicatorsService.loadIndicators();
-      this.indicatorsService.get().subscribe(data => this.indicators = data);
+      this.indicatorsService.get().subscribe(data => {
+          this.yearlyIndicators = data.filter(i => i.time_aggregation === 'yearly');
+      });
     }
-
 }


### PR DESCRIPTION
## Overview

Filters the sidebar list to only show yearly indicators.


### Demo

![cclab-sidebar-no-daily](https://cloud.githubusercontent.com/assets/1818302/18562341/50f80912-7b51-11e6-9ba0-9317657b0f13.png)


## Testing

This PR cannot be tested properly until azavea/climate-change-api#93 is merged and deployed. Until then, the sidebar will be blank on this branch. The demo screenshot was generated by manually changing the filter condition. 

Closes #56, Depends on azavea/climate-change-api#93

