### PR TITLE
Specify Accept header for JSON response

### DIFF
--- a/src/app/auth/api-http.service.ts
+++ b/src/app/auth/api-http.service.ts
@@ -48,6 +48,7 @@ export class ApiHttp extends Http {
             options.headers = new Headers();
         }
         options.headers.set('Authorization', 'Token ' + this.authService.getToken());
+        options.headers.set('Accept', 'application/json')
 
         if (options.search == null) {
             options.search = new URLSearchParams();
@@ -57,7 +58,6 @@ export class ApiHttp extends Http {
         if (typeof options.search === 'string') {
             options.search = new URLSearchParams(options.search);
         }
-        options.search.append('format', 'json');
 
         return options;
     }

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -27,7 +27,7 @@ import * as _ from 'lodash';
 })
 export class LabComponent implements OnInit, OnDestroy {
 
-  public apiCities: string = apiHost + "/api/city/?search=:keyword&format=json";
+  public apiCities: string = apiHost + "/api/city/?search=:keyword";
   public climateModels: ClimateModel[] = [];
   public scenarios: Scenario[] = [];
   public project: Project;


### PR DESCRIPTION
## Overview
Because of [a bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=918752), XHR requests that do not specify an Accept
header get one requesting for an HTML response by default. The Django
Rest Framework uses the Accept header to specify how to serialize the
response, which means that we previously had to manually specify
"?format=json" in each request. Using the Accept header for this better
fits the HTTP style, frees up space in the request URL, and bypasses the
Firefox bug entirely.

### Demo
![screen shot 2016-09-27 at 1 48 57 pm](https://cloud.githubusercontent.com/assets/1032849/18885304/2dd13e38-84b9-11e6-9273-035c3f687135.png)

## Testing Instructions
In a Firefox browser, open the Developer Network tools and navigate to the Climate Change Lab. You should see XHR requests for REST endpoints in `/api/`, select any of those and in the left panel below "Request headers" you should see a line that says `Accept: "application/json"`

Closes #83 

