### PR TITLE
Read time aggregation from indicator JSON

### DIFF
--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -50,8 +50,8 @@ export class LineGraphComponent {
         this.htmlElement = this.element.nativeElement;
         this.host = D3.select(this.element.nativeElement);
         this.timeOptions = {
-          'Yearly': '%Y',
-          'Daily': '%Y-%m-%d'
+          'yearly': '%Y',
+          'daily': '%Y-%m-%d'
         }
     }
 
@@ -79,7 +79,7 @@ export class LineGraphComponent {
         // Preserves parent data by fresh copying indicator data that will undergo processing
         let clippedData = _.cloneDeep(_.find(this.data, obj => obj.indicator.name === this.indicator.name));
         if (clippedData) {
-            this.timeFormat = this.timeOptions[clippedData.time_agg[0]];
+            this.timeFormat = this.timeOptions[clippedData.time_agg];
         }
         _.has(clippedData, 'data') ? this.extractedData = clippedData['data'] : this.extractedData = [];
         // Remove empty day in non-leap years (affects only daily data)

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -48,7 +48,7 @@ export class ChartService {
                 chartData.push({
                     'indicator': indicator,
                     'data': indicatorData,
-                    'time_agg': indicator.label.match(/Daily/) || indicator.label.match(/Yearly/)
+                    'time_agg': indicator.time_aggregation
                 } as ChartData);
             }
         });


### PR DESCRIPTION
## Overview
Previously we detected the indicator's aggregation level (Yearly,
monthly, day) from the title of the indicator, rather than the
time_aggregation object within the JSON response. This causes indicators
that don't feature that word to be interpreted incorrectly, as well as
posing translation concerns for the future. By using the JSON response
directly we alleviate those problems.

### Notes
Necessary for azavea/climate-change-api#110

## Testing Instructions
* In the climate-change-api project, check out the `feature/hwdi_indicator` branch and follow the testing instructions for azavea/climate-change-api#110 to load the required historic data for that indicator
* Attempt to graph the Heat Wave Duration Index indicator.
* You should see a graph
