### PR TITLE
Closes #81: Add CSV generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "d3": "^4.1.1",
     "d3-tip": "^0.6.7",
     "es6-shim": "^0.35.0",
+    "file-saver": "^1.3.2",
     "jquery": "2.2.2",
     "lodash": "^4.8.2",
     "ng2-bootstrap": "1.1.5",
+    "papaparse": "^4.1.2",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "~0.6.12"
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { ApiHttp } from './auth/api-http.service';
 import { AuthService } from './auth/auth.service';
 import { AuthGuard } from './auth/auth.guard';
 import { ChartService } from './services/chart.service';
+import { CSVService } from './services/csv.service';
 import { ClimateModelService } from './services/climate-model.service';
 import { IndicatorService } from './services/indicator.service';
 import { ScenarioService } from './services/scenario.service';
@@ -90,6 +91,7 @@ let ApiHttpProvider = {
     AuthService,
     AuthGuard,
     ChartService,
+    CSVService,
     ClimateModelService,
     IndicatorService,
     ScenarioService,

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -3,8 +3,13 @@
     {{chart.indicator.label}}
     </h2>
     <div class="chart-actions">
-        <button class="button button-link" tooltipPlacement="bottom" tooltipTrigger="mouseenter"
-            tooltipPopupDelay="300" title="" tooltip="Export"><i class="icon icon-export"></i>
+        <button class="button button-link"
+                tooltipPlacement="bottom"
+                tooltipTrigger="mouseenter"
+                tooltipPopupDelay="300"
+                title=""
+                tooltip="Export"
+                (click)="onExportClicked()"><i class="icon icon-export"></i>
         </button>
         <button class="button button-link"
                 tooltipPlacement="bottom"

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -7,6 +7,7 @@ import { Scenario } from '../models/scenario';
 
 import { ChartService } from '../services/chart.service';
 import { IndicatorService } from '../services/indicator.service';
+import { CSVService } from '../services/csv.service';
 
 /*
  * Chart component
@@ -29,7 +30,8 @@ export class ChartComponent implements OnChanges {
     private chartData: ChartData[];
 
     constructor(private chartService: ChartService,
-                private indicatorService: IndicatorService) {}
+                private indicatorService: IndicatorService,
+                private csvService: CSVService) {}
 
     ngOnChanges() {
         this.chartData = [];
@@ -48,6 +50,10 @@ export class ChartComponent implements OnChanges {
 
     onSettingChange() {
         this.onChartSettingChanged.emit(this.chart);
+    }
+
+    onExportClicked() {
+        this.csvService.downloadAsCSV(this.chartData);
     }
 
     removeChart(chart: Chart) {

--- a/src/app/services/csv.service.ts
+++ b/src/app/services/csv.service.ts
@@ -1,0 +1,31 @@
+import {Injectable} from '@angular/core';
+import 'rxjs/Rx';
+import * as Papa from 'papaparse';
+import * as _ from 'lodash';
+import * as FileSaver from 'file-saver';
+
+/*
+ * Generates CSV
+ */
+@Injectable()
+export class CSVService {
+
+    public dataToCSV(data): string {
+        let label = data[0].indicator.name + '-' + data[0].indicator.default_units;
+        let body = _(data[0].data)
+                       .map((row) => _.extend({ date: row.date }, row.values))
+                       .map((row) => _.mapKeys(row, (value, key) =>
+                                                    key === 'date' ? 'date' : label + '-' + key
+                                              )).value();
+        return Papa.unparse(body);
+    }
+
+    public downloadAsCSV(data): void {
+        let filename = data[0].indicator.name + '.csv';
+        this.downloadFile(this.dataToCSV(data), filename, 'text/csv');
+    }
+
+    private downloadFile(data: string, title: string, mime: string): void {
+        FileSaver.saveAs(new File([data], title, {type: mime + ";charset=utf-8"}));
+    }
+}


### PR DESCRIPTION
## Overview

Adds CSV generation, wired up to the export button on indicators.


### Demo

```csv
date,yearly_average_low_temperature-F-max,yearly_average_low_temperature-F-avg,yearly_average_low_temperature-F-min
2006,48.14064884551641,46.531764415285544,44.577624311054535
2007,48.11525056185803,46.757525496212054,45.03596112813017
2008,49.58573355896897,47.115230250696946,45.58771409126177
2009,48.692854806560604,46.531854667290354,44.46906418891757
2010,49.2633209479352,47.094595746602245,44.60362112384962
2011,48.7349015912618,46.96759885306468,45.167172349902785
2012,49.247483620566186,47.29783730299485,46.072767534099796
2013,48.744396487718575,47.29448393521246,45.73831497819441
2014,49.466939446436015,47.42937918168448,45.7629223967258
```


### Notes

Requires `npm install`


## Testing Instructions

* `npm install`
* Try exporting an indicator

Closes #81 

