### PR TITLE
Single-chart data scrubber

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -41,7 +41,7 @@
         [max]="chart.showMaximum"
         [minVal]="chart.minimumValue"
         [maxVal]="chart.maximumValue"
-        [isHover]="isHover">
+        [hover]="isHover">
     </line-graph>
     <div class="chart-options" *ngIf="chart.showSettings">
         <h4 class="margin-top-0 h5">Options</h4>

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -40,7 +40,8 @@
         [min]="chart.showMinimum"
         [max]="chart.showMaximum"
         [minVal]="chart.minimumValue"
-        [maxVal]="chart.maximumValue">
+        [maxVal]="chart.maximumValue"
+        [isHover]="isHover">
     </line-graph>
     <div class="chart-options" *ngIf="chart.showSettings">
         <h4 class="margin-top-0 h5">Options</h4>

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, HostListener } from '@angular/core';
 
 import { Chart, ChartData } from '../models/chart';
 import { City } from '../models/city';
@@ -28,10 +28,23 @@ export class ChartComponent implements OnChanges {
     @Input() city: City;
 
     private chartData: ChartData[];
+    private isHover: Boolean;
+
+    @HostListener('mouseover', ['$event'])
+    onMouseOver(event) {
+      this.isHover = true;
+    }
+
+    @HostListener('mouseleave', ['$event'])
+    onMouseOut(event) {
+      this.isHover = false;
+    }
 
     constructor(private chartService: ChartService,
                 private indicatorService: IndicatorService,
-                private csvService: CSVService) {}
+                private csvService: CSVService) {
+        this.isHover = false;
+    }
 
     ngOnChanges() {
         if (!this.scenario || !this.city || !this.models) { return; }

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -28,23 +28,18 @@ export class ChartComponent implements OnChanges {
     @Input() city: City;
 
     private chartData: ChartData[];
-    private isHover: Boolean;
+    private isHover: Boolean = false;
 
+    // Mousemove event must be at this level to listen to mousing over rect#overlay
+    // Should be configurable to make a cross-chart scrubber
     @HostListener('mouseover', ['$event'])
     onMouseOver(event) {
-      this.isHover = true;
-    }
-
-    @HostListener('mouseleave', ['$event'])
-    onMouseOut(event) {
-      this.isHover = false;
+        this.isHover = event.target.id === 'overlay'? true : false;
     }
 
     constructor(private chartService: ChartService,
                 private indicatorService: IndicatorService,
-                private csvService: CSVService) {
-        this.isHover = false;
-    }
+                private csvService: CSVService) {}
 
     ngOnChanges() {
         if (!this.scenario || !this.city || !this.models) { return; }

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -34,7 +34,7 @@ export class ChartComponent implements OnChanges {
     // Should be configurable to make a cross-chart scrubber
     @HostListener('mouseover', ['$event'])
     onMouseOver(event) {
-        this.isHover = event.target.id === 'overlay'? true : false;
+        this.isHover = event.target.id === 'overlay' ? true : false;
     }
 
     constructor(private chartService: ChartService,

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -140,7 +140,7 @@ export class LineGraphComponent {
         const maxY = D3.max(_.map(this.extractedData, d => d.values.max));
         const yPad = (maxY - minY) > 0 ? (maxY - minY) * 1/3 : 5; // Note: 5 as default is arbitrary
         // if minY is 0, keep it that way
-        this.yScale.domain([minY == 0? minY: minY - yPad, maxY + yPad]);
+        this.yScale.domain([minY == 0 ? minY : minY - yPad, maxY + yPad]);
 
         // Expects line data as DataPoint[]
         this.valueline = D3.line()
@@ -327,13 +327,13 @@ export class LineGraphComponent {
             .attr('width', this.width);
 
         // Toggle scrubber visibility
-        this.hover? $('.' + this.id).toggleClass('hidden', false) : $('.' + this.id).toggleClass('hidden', true);
+        this.hover ? $('.' + this.id).toggleClass('hidden', false) : $('.' + this.id).toggleClass('hidden', true);
     }
 
     private redrawScrubber(event) {
         let xPos = event.offsetX - this.margin.left;
         // Firefox handles event positioning differently than Chrome, Safari
-        if (navigator.userAgent.indexOf('Firefox') != -1) {
+        if (navigator && navigator.userAgent.toLowerCase().indexOf('firefox') !== -1) {
             xPos = event.offsetX;
         }
 

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -109,7 +109,7 @@ export class LineGraphComponent {
 
     /* Will setup the chart basics */
     private setup(): void {
-        this.margin = { top: 20, right: 20, bottom: 40, left: 40 };
+        this.margin = { top: 20, right: 50, bottom: 40, left: 50 };
         this.width = $('.chart').width() - this.margin.left - this.margin.right;
         this.height = 200 - this.margin.top - this.margin.bottom;
         this.xScale = D3.scaleTime().range([0, this.width]);

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -293,15 +293,6 @@ export class LineGraphComponent {
 
     private drawScrubber(): void {
         let indicator = this.indicator.name;
-        this.focus = this.svg.append('g')
-          .attr('class', indicator)
-          .classed('hidden', true);
-
-        this.focus.append('circle')
-          .attr('r', 4.5);
-
-        this.focus.append('text')
-          .attr('class', 'scrubber-text' + ' ' + indicator);
 
         // vertical scrub line
         this.svg.append('line')
@@ -310,11 +301,19 @@ export class LineGraphComponent {
           .attr('y1', 0).attr('y2', this.height)
           .classed('hidden', true);
 
-        // Sensory area
-        this.svg.append('rect')
-          .attr('class', 'overlay' + ' ' + indicator)
-          .attr('width', this.width)
-          .attr('height', this.height);
+        this.focus = this.svg.append('g')
+          .attr('class', indicator)
+          .classed('hidden', true);
+
+        this.focus.append('circle')
+          .attr('r', 4.5);
+
+        this.focus.append('rect')
+          .attr('class', 'scrubber-box' + ' ' + indicator)
+          .attr('height', 20);
+
+        this.focus.append('text')
+          .attr('class', 'scrubber-text' + ' ' + indicator);
 
         // Toggle scrubber visibility
         this.isHover? $('.'+ indicator).toggleClass('hidden', false) : $('.'+ indicator).toggleClass('hidden', true);
@@ -350,13 +349,23 @@ export class LineGraphComponent {
         this.focus
           .attr('transform', 'translate(' + xPos + ',' + this.yScale(yDatum) + ')');
 
-        this.svg.select('.scrubline')
+        this.svg.selectAll('.scrubline')
           .attr('transform', 'translate(' + xPos + ',' + 0 + ')');
 
         //update scrubber text
-        D3.select('.scrubber-text.' + this.indicator.name)
-           .text(yDatum.toFixed(2) + ' ' + this.data[0]['indicator']['default_units'])
-           .attr('transform', 'translate(' + -25 + ',' + -15 + ')');
+        let labelText = yDatum.toFixed(2) + ' ' + this.data[0]['indicator']['default_units'];
+        let textSVG = D3.select('.scrubber-text.' + this.indicator.name)
+          .text(labelText);
+
+        // center text
+        let labelWidth = textSVG.node().getBBox().width;
+        textSVG
+          .attr('transform', 'translate(' + -labelWidth/2 + ',' + -15 + ')');
+
+        //update text box length
+        D3.select('.scrubber-box.' + this.indicator.name)
+          .attr('width', textSVG.node().getBBox().width + 10)
+          .attr('transform', 'translate(' + -(labelWidth/2 + 5) + ',' + -30 + ')');
     }
 
     private drawLine(data: Array<DataPoint>, className: string): void {

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -13,7 +13,7 @@ import * as $ from 'jquery';
   selector: 'line-graph',
   encapsulation: ViewEncapsulation.None,
   template: `<ng-content></ng-content>`,
-  inputs: [ 'data', 'indicator', 'trendline', 'min', 'max', 'minVal', 'maxVal', 'isHover' ]
+  inputs: [ 'data', 'indicator', 'trendline', 'min', 'max', 'minVal', 'maxVal', 'hover' ]
 })
 
 export class LineGraphComponent {
@@ -26,7 +26,7 @@ export class LineGraphComponent {
     public max: Boolean;
     public minVal: number;
     public maxVal: number;
-    public isHover: Boolean;
+    public hover: Boolean;
 
     private host;                          // D3 object referebcing host dom object
     private svg;                           // SVG in which we will print our chart
@@ -66,7 +66,7 @@ export class LineGraphComponent {
 
     @HostListener('mousemove', ['$event'])
     onMouseMove(event) {
-      if (this.isHover) {
+      if (this.hover) {
         this.handleMouseOverGraph(event);
       }
     }
@@ -316,7 +316,7 @@ export class LineGraphComponent {
           .attr('class', 'scrubber-text' + ' ' + indicator);
 
         // Toggle scrubber visibility
-        this.isHover? $('.'+ indicator).toggleClass('hidden', false) : $('.'+ indicator).toggleClass('hidden', true);
+        this.hover? $('.'+ indicator).toggleClass('hidden', false) : $('.'+ indicator).toggleClass('hidden', true);
     }
 
     private handleMouseOverGraph(event) {

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -301,7 +301,7 @@ export class LineGraphComponent {
           .attr('r', 4.5);
 
         this.focus.append('text')
-          .attr('class', 'scrubber-text');
+          .attr('class', 'scrubber-text' + ' ' + indicator);
 
         // vertical scrub line
         this.svg.append('line')
@@ -354,7 +354,7 @@ export class LineGraphComponent {
           .attr('transform', 'translate(' + xPos + ',' + 0 + ')');
 
         //update scrubber text
-        D3.select('.scrubber-text')
+        D3.select('.scrubber-text.' + this.indicator.name)
            .text(yDatum.toFixed(2) + ' ' + this.data[0]['indicator']['default_units'])
            .attr('transform', 'translate(' + -25 + ',' + -15 + ')');
     }

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -152,12 +152,12 @@ chart {
     }
 
     .scrubber-box {
-      line-height: 1;
-      font-weight: bold;
-      padding: 12px;
-      background: rgba(0, 0, 0, 0.8);
-      color: #fff;
-      border-radius: 2px;
+      fill: black;
+    }
+
+    .scrubber-text {
+      fill: white;
+      stroke: white;
     }
   }
 

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -139,6 +139,32 @@ chart {
     opacity: .3;
   }
 
+  .overlay {
+    fill: none;
+    pointer-events: all;
+  }
+
+  g {
+    circle {
+      fill: none;
+      stroke: black;
+      stroke-width: 2.5px;
+    }
+
+    .scrubber-box {
+      line-height: 1;
+      font-weight: bold;
+      padding: 12px;
+      background: rgba(0, 0, 0, 0.8);
+      color: #fff;
+      border-radius: 2px;
+    }
+  }
+
+  .scrubline {
+    stroke: #757575;
+  }
+
   .chart-controls {
     color: black;
 

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -139,7 +139,7 @@ chart {
     opacity: .3;
   }
 
-  .overlay {
+  #overlay {
     fill: none;
     pointer-events: all;
   }


### PR DESCRIPTION
## Overview

Individual chart data scrubbers!


### Demo

**Prototype:**
https://cloud.githubusercontent.com/assets/1818302/18316520/f0f13a3e-74e8-11e6-86ab-8cd037dbdd68.png

**Demo:**
<img width="480" alt="screen shot 2016-10-17 at 5 25 41 pm" src="https://cloud.githubusercontent.com/assets/10568752/19456325/deb2fb58-948e-11e6-86f2-265757af3e8f.png">

### Notes

Events are tricky, especially between browsers. I tried all sorts of ways in all sorts of places.
1) **D3's built in svg event handler** ( e.g, your_svg.on('mouseover')) -- crucial event information not recognized in Firefox.
2) **JQuery events** -- Event information avail across browsers however this method resulted in event listeners expiring after use, which is not useful. Also, JQuery.
3) **Angular HostListeners** --most functional solution I have now. 

You will see there is a host listener at chart-component level and another at line-graph-component level. I am not certain how expensive it is to have listeners in both places but doing so was necessary in practice. Initial, failed, strategy was there would just be a listener at line-graph-component level only. Of benefit, I think this structure helps set up the cross-chart scrubber.

**D3 & Tooltip**
To the best of my figuring, d3-tooltip would not work here here combined with the moving mouseover scrubber. This unusual alternative is a bunch of layered SVG elements created and destroyed based on mouse events.

We will want to adjust unit options here or on the API side. For example, "count" is not a unit and labelling "15 count" is awkward.

Closes #48 