### PR TITLE
Feature/multi chart scrubber

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -41,7 +41,8 @@
         [max]="chart.showMaximum"
         [minVal]="chart.minimumValue"
         [maxVal]="chart.maximumValue"
-        [hover]="isHover">
+        [hover]="isHover"
+        [multiChartScrubber]="multiChartScrubber">
     </line-graph>
     <div class="chart-options" *ngIf="chart.showSettings">
         <h4 class="margin-top-0 h5">Options</h4>

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, HostListener } from '@angular/core';
+import { Component, EventEmitter, OnChanges, Input, Output, HostListener } from '@angular/core';
 
 import { Chart, ChartData } from '../models/chart';
 import { City } from '../models/city';
@@ -26,15 +26,18 @@ export class ChartComponent implements OnChanges {
     @Input() scenario: Scenario;
     @Input() models: ClimateModel[];
     @Input() city: City;
+    @Input() multiChartScrubber: Boolean;
 
     private chartData: ChartData[];
     private isHover: Boolean = false;
 
     // Mousemove event must be at this level to listen to mousing over rect#overlay
-    // Should be configurable to make a cross-chart scrubber
     @HostListener('mouseover', ['$event'])
     onMouseOver(event) {
         this.isHover = event.target.id === 'overlay' ? true : false;
+        if (this.multiChartScrubber) {
+            this.chartService.detectMultiChartHover(this.isHover);
+        }
     }
 
     constructor(private chartService: ChartService,

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -1,9 +1,11 @@
-import { Component, ViewEncapsulation, ElementRef, HostListener } from '@angular/core';
+import { Component, ViewEncapsulation, ElementRef, HostListener, OnInit, OnDestroy } from '@angular/core';
 import { ChartData, DataPoint } from '../models/chart';
 import { Indicator } from '../models/indicator.models';
 import * as D3 from 'd3';
 import * as _ from 'lodash';
 import * as $ from 'jquery';
+
+import { ChartService } from '../services/chart.service';
 
 /*
  * Line graph component
@@ -13,10 +15,10 @@ import * as $ from 'jquery';
   selector: 'line-graph',
   encapsulation: ViewEncapsulation.None,
   template: `<ng-content></ng-content>`,
-  inputs: [ 'data', 'indicator', 'trendline', 'min', 'max', 'minVal', 'maxVal', 'hover' ]
+  inputs: [ 'data', 'indicator', 'trendline', 'min', 'max', 'minVal', 'maxVal', 'hover', 'multiChartScrubber' ]
 })
 
-export class LineGraphComponent {
+export class LineGraphComponent implements OnInit, OnDestroy {
 
     public data: ChartData[];
     public extractedData: Array<DataPoint>;
@@ -27,6 +29,7 @@ export class LineGraphComponent {
     public minVal: number;
     public maxVal: number;
     public hover: Boolean;
+    public multiChartScrubber: Boolean;
 
     private host;                          // D3 object referebcing host dom object
     private svg;                           // SVG in which we will print our chart
@@ -49,11 +52,13 @@ export class LineGraphComponent {
                                            // Not a perfect solution should the random int and indicator be the same
                                            // However, this is quite unlikely (1/10000, and even less likely by way of app use)
 
+    private multiChartScrubberHoverSubscription;
+    private multiChartScrubberInfoSubscription;
 
     /* We request angular for the element reference
     * and then we create a D3 Wrapper for our host element
     */
-    constructor(private element: ElementRef) {
+    constructor(private element: ElementRef, private chartService: ChartService) {
         this.htmlElement = this.element.nativeElement;
         this.host = D3.select(this.element.nativeElement);
         this.timeOptions = {
@@ -64,18 +69,23 @@ export class LineGraphComponent {
 
     @HostListener('window:resize', ['$event'])
     onResize(event) {
-      this.ngOnChanges();
+        this.ngOnChanges();
     }
 
     // If the chart is being hovered over, handle mouse movements
     @HostListener('mousemove', ['$event'])
     onMouseMove(event) {
-      if (this.hover) {
-        this.redrawScrubber(event);
-      }
+        // for single-chart scrubber
+        if (this.hover && !this.multiChartScrubber) {
+            this.redrawScrubber(event);
+        }
+        // for multi-chart scrubber
+        if (this.multiChartScrubber) {
+            this.chartService.updateMultiChartScrubberInfo(event);
+        }
     }
 
-    /* Will Update on every @Input change */
+    /* Executes on every @Input change */
     ngOnChanges(): void {
         if (!this.data || this.data.length === 0) return;
         this.filterData();
@@ -90,6 +100,29 @@ export class LineGraphComponent {
         this.drawYAxis();
         this.drawAvgLine();
         this.drawScrubber();
+    }
+
+    ngOnInit(): void {
+        // Set up global chart mouseover communication chain if set to multi-chart scrubber
+        if (this.multiChartScrubber) {
+            this.multiChartScrubberHoverSubscription = this.chartService.multiChartScrubberHover$.subscribe(data => {
+                this.hover = data;
+                this.hover ? $('.' + this.id).toggleClass('hidden', false) : $('.' + this.id).toggleClass('hidden', true);
+            });
+            this.multiChartScrubberInfoSubscription = this.chartService.multiChartScrubberInfo$.subscribe(event => {
+                // Only redraw if a chart is moused over
+                if (this.hover) {
+                    this.redrawScrubber(event)
+                }
+            });
+        }
+    }
+
+    ngOnDestroy(): void {
+        if (this.multiChartScrubber) {
+            this.multiChartScrubberInfoSubscription.unsubscribe();
+            this.multiChartScrubberHoverSubscription.unsubscribe();
+        }
     }
 
     private filterData(): void {
@@ -372,7 +405,7 @@ export class LineGraphComponent {
 
         // Update text box length
         D3.select('.scrubber-box.' + this.id)
-            .attr('width', textSVG.node().getBBox().width + 10)
+            .attr('width', labelWidth + 10)
             .attr('transform', 'translate(' + -(labelWidth/2 + 5) + ',' + -30 + ')');
     }
 

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -104,7 +104,8 @@ export class LineGraphComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         // Set up global chart mouseover communication chain if set to multi-chart scrubber
-        if (this.multiChartScrubber) {
+        // ** CURRENTLY ONLY FOR YEARLY INDICATORS**
+        if (this.multiChartScrubber && this.indicator.time_aggregation === 'yearly') {
             this.multiChartScrubberHoverSubscription = this.chartService.multiChartScrubberHover$.subscribe(data => {
                 this.hover = data;
                 this.hover ? $('.' + this.id).toggleClass('hidden', false) : $('.' + this.id).toggleClass('hidden', true);
@@ -119,7 +120,7 @@ export class LineGraphComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (this.multiChartScrubber) {
+        if (this.multiChartScrubber && this.indicator.time_aggregation === 'yearly') {
             this.multiChartScrubberInfoSubscription.unsubscribe();
             this.multiChartScrubberHoverSubscription.unsubscribe();
         }

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -106,11 +106,11 @@ export class LineGraphComponent implements OnInit, OnDestroy {
         // Set up global chart mouseover communication chain if set to multi-chart scrubber
         // ** CURRENTLY ONLY FOR YEARLY INDICATORS**
         if (this.multiChartScrubber && this.indicator.time_aggregation === 'yearly') {
-            this.multiChartScrubberHoverSubscription = this.chartService.multiChartScrubberHover$.subscribe(data => {
+            this.multiChartScrubberHoverSubscription = this.chartService.multiChartScrubberHoverObservable.subscribe(data => {
                 this.hover = data;
                 this.hover ? $('.' + this.id).toggleClass('hidden', false) : $('.' + this.id).toggleClass('hidden', true);
             });
-            this.multiChartScrubberInfoSubscription = this.chartService.multiChartScrubberInfo$.subscribe(event => {
+            this.multiChartScrubberInfoSubscription = this.chartService.multiChartScrubberInfoObservable.subscribe(event => {
                 // Only redraw if a chart is moused over
                 if (this.hover) {
                     this.redrawScrubber(event)

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -27,6 +27,7 @@
                    [city]="project.city"
                    [models]="project.models"
                    [scenario]="project.scenario"
+                   [multiChartScrubber]="project.multiChartScrubber"
                    (onRemoveChart)="removeChart($event)"
                    (onChartSettingChanged)="chartSettingChanged()"></chart>
           </div>

--- a/src/app/models/project.ts
+++ b/src/app/models/project.ts
@@ -18,6 +18,7 @@ export class Project {
     allModels: boolean = true;
     models: ClimateModel[] = [];
     charts: Chart[] = [];
+    multiChartScrubber: boolean = false;
 
     constructor(object: Object) {
         Object.assign(this, object);
@@ -36,7 +37,8 @@ export class Project {
             scenario: this.scenario,
             allModels: this.allModels,
             models: this.models,
-            charts: this.charts
+            charts: this.charts,
+            multiChartScrubber: this.multiChartScrubber
         };
     }
 

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -33,6 +33,12 @@
                         <model-modal [project]="model.project"></model-modal>
                     </div>
                 </div>
+                <div class="row">
+                    <label>
+                        <input type="checkbox" name="multiChartScrubber"  [(ngModel)]="model.project.multiChartScrubber">
+                        Multi-Chart Scrubber
+                    </label>
+                </div>
                 <div class="row align-center">
                     <button type="submit"
                             class="button button-primary"

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -1,5 +1,5 @@
-import {Injectable} from '@angular/core';
-import 'rxjs/Rx';
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
 
 import { ChartData, MultiDataPoint } from '../models/chart';
 
@@ -13,7 +13,22 @@ import * as _ from 'lodash';
 @Injectable()
 export class ChartService {
 
+    private multiChartScrubberInfo = new Subject();
+    private multiChartScrubberHover = new Subject<Boolean>();
+
+    multiChartScrubberInfo$ = this.multiChartScrubberInfo.asObservable();
+    multiChartScrubberHover$ = this.multiChartScrubberHover.asObservable();
+
     constructor() {}
+
+    // receive and ship mousemove event
+    updateMultiChartScrubberInfo(event) {
+        this.multiChartScrubberInfo.next(event);
+    }
+    // receive and ship overlay mouseover status
+    detectMultiChartHover(bool: Boolean) {
+        this.multiChartScrubberHover.next(bool);
+    }
 
     // return an array of date strings for each day in the given year
     getDaysInYear(year: number): string[] {

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -13,21 +13,21 @@ import * as _ from 'lodash';
 @Injectable()
 export class ChartService {
 
-    private multiChartScrubberInfo = new Subject();
-    private multiChartScrubberHover = new Subject<Boolean>();
+    private _multiChartScrubberInfo = new Subject();
+    private _multiChartScrubberHover = new Subject<Boolean>();
 
-    multiChartScrubberInfo$ = this.multiChartScrubberInfo.asObservable();
-    multiChartScrubberHover$ = this.multiChartScrubberHover.asObservable();
+    public multiChartScrubberInfoObservable = this._multiChartScrubberInfo.asObservable();
+    public multiChartScrubberHoverObservable = this._multiChartScrubberHover.asObservable();
 
     constructor() {}
 
     // receive and ship mousemove event
     updateMultiChartScrubberInfo(event) {
-        this.multiChartScrubberInfo.next(event);
+        this._multiChartScrubberInfo.next(event);
     }
     // receive and ship overlay mouseover status
     detectMultiChartHover(bool: Boolean) {
-        this.multiChartScrubberHover.next(bool);
+        this._multiChartScrubberHover.next(bool);
     }
 
     // return an array of date strings for each day in the given year


### PR DESCRIPTION
## Overview

Multi chart scrubber for yearly indicators!


### Demo

<img width="638" alt="screen shot 2016-10-20 at 11 30 24 am" src="https://cloud.githubusercontent.com/assets/10568752/19566754/63000b04-96b9-11e6-86c8-3be90e979240.png">

<img width="370" alt="screen shot 2016-10-20 at 11 55 26 am" src="https://cloud.githubusercontent.com/assets/10568752/19567579/3381a6e6-96bc-11e6-935c-9c1c2ea916f9.png">


<img width="348" alt="screen shot 2016-10-20 at 11 36 12 am" src="https://cloud.githubusercontent.com/assets/10568752/19566771/6c8ff3c8-96b9-11e6-834e-b1839e1b9cf0.png">


### Notes

Multi-scrubber depends upon 2 Observable streams. One listens for any chart #overlay being moused over and relays it to every line graph component. The other listens for mouse positioning and relays that to every line graph component to redraw the scrubber.

## Testing Instructions

Toggle multi-chart scrubber in project settings and mouse over charts.

Closes #97 
