### PR TITLE
Bump openjdk version to fix provisioning issue

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,4 +3,4 @@ nodejs_npm_version: 3.10.3
 
 ruby_version: 2.2
 
-java_version: '7u111-*'
+java_version: '7u121-*'


### PR DESCRIPTION
## Overview

This should fix the jenkins provisioning issue and allow the build to continue.

### Notes

Pulled the newer valid openjdk version by starting the VM and running the following:
```
vagrant@app:~$ sudo apt-get update
vagrant@app:~$ sudo apt-cache policy openjdk-7-jre-headless
openjdk-7-jre-headless:
  Installed: none
  Candidate: 7u121-2.6.8-1ubuntu0.12.04.1
  Version table:
 *** 7u121-2.6.8-1ubuntu0.12.04.1 0
        500 http://archive.ubuntu.com/ubuntu/ precise-updates/universe amd64 Packages
        500 http://security.ubuntu.com/ubuntu/ precise-security/universe amd64 Packages
        100 /var/lib/dpkg/status
     7~u3-2.1.1~pre1-1ubuntu2 0
        500 http://archive.ubuntu.com/ubuntu/ precise/universe amd64 Packages
```

## Testing Instructions

 * `vagrant provision` should complete successfully
