### PR TITLE
Remove 'closes' keyword from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,4 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case, and expected output
 
-See|Connects|Closes #XXX
+See|Connects #XXX


### PR DESCRIPTION
To avoid Waffle auto-closing issues.
