### PR TITLE
Update DNS to climate.azavea.com

### DIFF
--- a/example/constants.ts.example
+++ b/example/constants.ts.example
@@ -7,4 +7,4 @@
 export const defaultCity = {'id': 7, 'properties': {'name': 'Philadelphia','admin': 'PA'}};
 export const defaultScenario = 'RCP85';
 
-export const apiHost = 'https://api.staging.futurefeelslike.com';
+export const apiHost = 'https://climate.azavea.com';

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,6 +1,6 @@
 s3_id: <%= ENV['CCLAB_AWS_S3_ACCESS_KEY'] %>
 s3_secret: <%= ENV['CCLAB_AWS_S3_SECRET_ACCESS_KEY'] %>
-s3_bucket: lab.futurefeelslike.com
+s3_bucket: lab.climate.azavea.com
 
 # Below are examples of all the available configurations.
 # See README for more detailed info on each of them.


### PR DESCRIPTION
## Overview

Switched from api.futurefeelslike.com --> climate.azavea.com

Connects https://github.com/azavea/climate-change-api/issues/337