### PR TITLE
Fix build broken (somehow?) by #137

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@types/core-js": "~0.9.28",
-    "@types/jasmine": "~2.5.40",
+    "@types/jasmine": "2.5.38",
     "@types/jquery": "~1.10.31",
     "@types/node": "~4.0.29",
     "@types/selenium-webdriver": "~2.53.39",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
@@ -12,8 +12,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "baseUrl": "./src",
-    "paths": [
-    ],
+    "paths": [],
     "types": [
       "core-js",
       "jasmine",


### PR DESCRIPTION
## Overview

Fixes build broken by #137. Not sure how that actually broke the build since it doesn't touch any of the things changed here.

- Ensuring target and lib compiler options
  have matching ECMASCript versions fixed
  most issues, not sure why they were mismatched
  in the first place
- Locking to an older version of @types/jasmine
  fixed remaining linting issues, attempted "better"
  solution of upgrading typescript to 2.1.x but
  that failed with other errors

### Notes

Deferred the typescript upgrade as described above, we'll need to do that anyway if we migrate to Angular 4+, so that's a separate task. Might also be worth moving this project to Angular CLI if we continue to develop it, since that project is now out of beta.

## Testing Instructions

- `rm -rf node_modules`
- ` npm install`
- `npm start`

Should no longer spit errors? 🤞 

