### PR TITLE
Don't display Indicators with required params in sidebar

### DIFF
--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -31,10 +31,16 @@ export class SidebarComponent implements OnInit {
     }
 
     private groupIndicators(indicators: Indicator[]) {
-        this.tempIndicators = indicators.filter(i => {
+        // Filter any indicators with "required" params, we can't currently display them
+        //  without changes to the Lab
+        // TODO: Remove this filter once we've implemented user controls for indicator parameters
+        const visibleIndicators = indicators.filter(i => {
+            return !i.parameters.some(p => p.required);
+        });
+        this.tempIndicators = visibleIndicators.filter(i => {
             return (i.variables.indexOf('tasmax') !== -1 || i.variables.indexOf('tasmin') !== -1);
         });
-        this.precipIndicators = indicators.filter(i => {
+        this.precipIndicators = visibleIndicators.filter(i => {
             return i.variables.indexOf('pr') !== -1;
         });
     }


### PR DESCRIPTION
## Overview

We need to make changes to the Lab to properly display any indicator with a required parameter. When a user selects one now, the graph just "loads" infinitely because we don't display an error message when the API request for data fails. Since allowing users to set values for required parameters would take significant design/dev effort, for now we just skip adding them to the sidebar.

Currently applies to:
- max temp threshold
- min temp threshold
- precip threshold

All other indicators with extra params, e.g. Cooling Degree Days, provide defaults for their extra params.

### Demo

Here's the new valid indicator list in the sidebar:
![screen shot 2017-06-23 at 09 45 34](https://user-images.githubusercontent.com/1818302/27484867-c1c97ce6-57f8-11e7-8b88-4b2d4415b856.png)


## Testing Instructions

 * Load up the lab. Shouldn't have any indicators that don't complete successfully (barring throttling errors)

Closes #141 
