### PR TITLE
Run linter before prod build in CI

### DIFF
--- a/.jenkins/deploy.sh
+++ b/.jenkins/deploy.sh
@@ -11,5 +11,5 @@ vagrant up && vagrant ssh -c "
   source .env
   npm install
   npm rebuild node-sass
-  npm run build:prod && s3_website push
+  npm run lint && npm run build:prod && s3_website push
 "


### PR DESCRIPTION
## Overview

Run linter as part of Jenkins build, and fail if the linter is unhappy

## Testing Instructions

We'll have to wait and see how this shakes out. The build is currently configured to only run and deploy on merges to develop. `ng lint` states that it returns non-zero if linting returns greater than zero errors (verified in terminal), so that would fail the bash `&&` condition and then the build.

Closes #149 
