### PR TITLE
Feature/kak/fix test runner#145

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 coverage/
 build/
 dist/
+violations.xml
 
 # Vagrant
 .vagrant/

--- a/ansible/roles/climate-change-lab.app/tasks/main.yml
+++ b/ansible/roles/climate-change-lab.app/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
-  - name: Install build dependencies
+  - name: Install packages
     apt: name={{ item }} state=present
     with_items:
       - g++
+      - chromium-browser
 
   - name: "Install node dependencies"
     npm: path={{ app_dir }}
@@ -16,3 +17,11 @@
 
   - name: "Install s3_website gem"
     gem: name=s3_website user_install=no state=latest
+
+  # so test runner can find browser
+  - name: "Set path to Chromium"
+    lineinfile:
+      path: '/etc/environment'
+      state: present
+      regexp: '^CHROME_BIN='
+      line: CHROME_BIN=/usr/bin/chromium-browser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['ChromeHeadless'],
+    singleRun: true
   });
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:prod": "ng build -prod --aot --extract-css",
     "test": "ng test",
     "lint": "ng lint --type-check",
+    "lint:ci": "ng lint --type-check --format checkstyle > violations.xml",
     "e2e": "ng e2e"
   },
   "private": true,


### PR DESCRIPTION
## Overview

Fixes test runner. Install Chromium in VM, so tests run via Chrome headless may be run within vagrant environment. Also adds a CI linter run option, for the upcoming Jenkins test/lint run task.

## Testing Instructions

 * `vagrant provision`
 * `vagrant ssh`
 * `cd /vagrant`
 * `npm run test`
 * Tests should run to completion

Fixes #145
