### PR TITLE
Add clarifying login text and fill dashboard lorem ipsum

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "papaparse": "^4.1.2",
     "rxjs": "^5.1.0",
     "save-svg-as-png": "^1.0.3",
-    "zone.js": "^0.8.4"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angular/cli": "1.1.1",

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -50,7 +50,11 @@
                 <h2>API</h2>
             </div>
             <div class="about-body">
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum
+                We created Azavea's Climate API in order to give you easy access to the <a href="https://aws.amazon.com/public-datasets/nasa-nex/" target="_blank">NASA NEX-GDDP</a> data without the hassle of having to download and wrangle a NetCDF dataset. With each query, you can choose from over 1,000 U.S. locations, either of the two most commonly used RCPs, 22 indicators of temperature and precipitation, and anytime 1950-2100.
+                <p>
+                <p>
+                To get started with the API, please review
+                <a href="https://docs.climate.azavea.com" target="_blank">the documentation</a>.
             </div>
         </div>
     </section>

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -5,6 +5,8 @@
     <div class="login-body">
         <div class="login-box">
             <h3>Login</h3>
+            <br>Using your Climate API account information
+            <p>
 
             <form (ngSubmit)="onSubmit()" #loginForm="ngForm">
                 <label for="email">E-mail</label>
@@ -29,7 +31,9 @@
             </form>
 
             <a href="{{ createAccountUrl }}">Create an account</a>
-            <a href="{{ resetPasswordUrl }}">Reset your password</a>
+            <p>
+            <p>
+            If you already registered, but do not know your password please <a href="{{ resetPasswordUrl }}">reset your password</a>.
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Demo

<img width="598" alt="screen shot 2017-07-12 at 4 21 08 pm" src="https://user-images.githubusercontent.com/10568752/28138288-38daab8c-671e-11e7-9cd2-dd7709746306.png">
<img width="397" alt="screen shot 2017-07-12 at 3 28 39 pm" src="https://user-images.githubusercontent.com/10568752/28138296-41e29604-671e-11e7-94ac-70fee8e2871b.png">


### Notes

I tweaked the suggested text to fit the space better


## Testing Instructions
`npm run serve`

Closes #144  #155 
