### PR TITLE
Display one chart only

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "zone.js": "0.8.12"
   },
   "devDependencies": {
-    "@angular/cli": "1.1.1",
+    "@angular/cli": "1.2.6",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",
     "@types/jasmine": "2.5.45",

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -21,9 +21,9 @@
           </div>
           <div class="nav-right"></div>
         </nav>
-        <div class="charts scrollable">
-          <div class="chart" *ngFor="let chart of project.project_data.charts">
-            <ccl-chart [chart]="chart"
+        <div class="chart-container scrollable">
+          <div class="chart" *ngIf="project.project_data.charts[0]">
+            <ccl-chart [chart]="project.project_data.charts[0]"
                        [city]="project.project_data.city"
                        [models]="project.project_data.models"
                        [scenario]="project.project_data.scenario"

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -66,12 +66,11 @@ export class LabComponent implements OnInit, OnDestroy {
     }
 
     public removeChart(chart: Chart) {
-        this.project.project_data.charts =
-            this.project.project_data.charts.filter(c => c !== chart);
+        this.project.project_data.charts = [];
     }
 
     public indicatorSelected(indicator: Indicator) {
         const chart = new Chart({indicator: indicator});
-        this.project.project_data.charts.unshift(chart);
+        this.project.project_data.charts = [chart];
     }
 }

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -1,10 +1,9 @@
 .chart {
   background-color: #fff;
   box-shadow: 2px 2px 10px rgba(0,0,0,.05);
-  margin-bottom: 2rem;
 }
 
-.charts {
+.chart-container {
   padding: 2rem 1.5rem;
 }
 


### PR DESCRIPTION
## Overview

Change the view such that we only have 1 chart going at a time. 


### Notes

I made a simple change though there are more places where changes could be made that would clean away having multi charts completely, such as adjusting models. From discussion it was my understanding that we didn't want to change things too much?

## Testing Instructions

`npm run serve`
http://localhost:4200

Closes #175
