### PR TITLE
Feature/jf/remove mult chart scrubber

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "zone.js": "0.8.12"
   },
   "devDependencies": {
-    "@angular/cli": "1.1.1",
+    "@angular/cli": "1.2.6",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",
     "@types/jasmine": "2.5.45",

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -41,8 +41,7 @@
         [max]="chart.showMaximum"
         [minVal]="chart.minimumValue"
         [maxVal]="chart.maximumValue"
-        [hover]="isHover"
-        [multiChartScrubber]="multiChartScrubber">
+        [hover]="isHover">
     </ccl-line-graph>
     <div class="chart-options" *ngIf="chart.showSettings">
         <div class="chart-options-body">

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -28,7 +28,6 @@ export class ChartComponent implements OnChanges {
     @Input() scenario: Scenario;
     @Input() models: ClimateModel[];
     @Input() city: City;
-    @Input() multiChartScrubber: Boolean;
 
     public chartData: ChartData[];
     public isHover: Boolean = false;
@@ -37,9 +36,6 @@ export class ChartComponent implements OnChanges {
     @HostListener('mouseover', ['$event'])
     onMouseOver(event) {
         this.isHover = event.target.id === 'overlay' ? true : false;
-        if (this.multiChartScrubber) {
-            this.chartService.detectMultiChartHover(this.isHover);
-        }
     }
 
     constructor(private chartService: ChartService,

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -27,7 +27,6 @@
                        [city]="project.project_data.city"
                        [models]="project.project_data.models"
                        [scenario]="project.project_data.scenario"
-                       [multiChartScrubber]="project.project_data.multiChartScrubber"
                        (onRemoveChart)="removeChart($event)"></ccl-chart>
           </div>
         </div>

--- a/src/app/models/project-data.model.ts
+++ b/src/app/models/project-data.model.ts
@@ -17,7 +17,6 @@ export class ProjectData {
     allModels = true;
     models: ClimateModel[] = [];
     charts: Chart[] = [];
-    multiChartScrubber = false;
 
     static fromJSON(object: Object) {
         return new this(object);
@@ -36,8 +35,7 @@ export class ProjectData {
             scenario: this.scenario,
             allModels: this.allModels,
             models: this.models,
-            charts: this.charts,
-            multiChartScrubber: this.multiChartScrubber
+            charts: this.charts
         };
     }
 }

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -33,12 +33,6 @@
                         <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
                     </div>
                 </div>
-                <div class="row">
-                    <label>
-                        <input type="checkbox" name="multiChartScrubber"  [(ngModel)]="model.project.project_data.multiChartScrubber">
-                        Multi-Chart Scrubber
-                    </label>
-                </div>
                 <div class="row align-center">
                     <button type="submit"
                             class="button button-primary"

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -15,14 +15,6 @@ import * as D3 from 'd3';
 @Injectable()
 export class ChartService {
 
-    /* tslint:disable:member-ordering */
-    private _multiChartScrubberInfo = new Subject();
-    private _multiChartScrubberHover = new Subject<Boolean>();
-
-    public multiChartScrubberInfoObservable = this._multiChartScrubberInfo.asObservable();
-    public multiChartScrubberHoverObservable = this._multiChartScrubberHover.asObservable();
-    /* tslint:enable:member-ordering */
-
     private timeOptions = {
           'yearly': '%Y',
           'daily': '%Y-%m-%d',
@@ -30,15 +22,6 @@ export class ChartService {
         };
 
     constructor() {}
-
-    // receive and ship mousemove event
-    updateMultiChartScrubberInfo(event) {
-        this._multiChartScrubberInfo.next(event);
-    }
-    // receive and ship overlay mouseover status
-    detectMultiChartHover(bool: Boolean) {
-        this._multiChartScrubberHover.next(bool);
-    }
 
     // return an array of date strings for each day in the given year
     getDaysInYear(year: number): string[] {


### PR DESCRIPTION
## Overview

In the lab revival we will only have one chart in view, thus making the multi-chart scrubber obsolete -- this PR removes it.


### Demo

<img width="422" alt="screen shot 2017-07-31 at 9 10 57 am" src="https://user-images.githubusercontent.com/10568752/28779178-41862368-75d0-11e7-8c22-ed714302c89a.png">

and

<img width="441" alt="screen shot 2017-07-31 at 9 11 53 am" src="https://user-images.githubusercontent.com/10568752/28779200-52f78c36-75d0-11e7-8372-0ea0fd45654d.png">


### Notes

The angular-cli upgrade is for a bug fix, see https://github.com/angular/angular-cli/commit/cc444072c35dba229b44a933354a074f44a16333

## Testing Instructions

`npm run serve`
http://localhost:4200

Closes #183
