### PR TITLE
Feature/kak/move download buttons#179

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -63,18 +63,18 @@
 </div>
 
 <div dropdown [dropup]="true" class="btn-group">
-  <button dropdownToggle class="button dropdown-toggle" type="button"
-    id="exportDropUp" data-toggle="dropdown" aria-haspopup="true"
-    aria-expanded="true">
-    <i class="icon icon-download"></i>
-    Download
-  </button>
-  <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="exportDropUp">
-    <li role="menuitem">
-      <a class="drowdown-item" (click)="onExportClicked()">Download JSON</a>
-    </li>
-    <li role="menuitem">
-      <a class="drowdown-item" (click)="onDownloadImageClicked()">Download Chart</a>
-    </li>
-  </ul>
+    <button dropdownToggle class="button dropdown-toggle" type="button"
+        id="exportDropUp" data-toggle="dropdown" aria-haspopup="true"
+        aria-expanded="true">
+        <i class="icon icon-download"></i>
+        Download
+    </button>
+    <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="exportDropUp">
+        <li role="menuitem">
+            <a class="drowdown-item" (click)="onExportClicked()">Download JSON</a>
+        </li>
+        <li role="menuitem">
+            <a class="drowdown-item" (click)="onDownloadImageClicked()">Download Chart</a>
+        </li>
+    </ul>
 </div>

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -6,18 +6,6 @@
         <button class="button button-link"
                 placement="top"
                 title=""
-                tooltip="Download chart image"
-                (click)="onDownloadImageClicked()"><i class="icon icon-download"></i>
-        </button>
-        <button class="button button-link"
-                placement="top"
-                title=""
-                tooltip="Export"
-                (click)="onExportClicked()"><i class="icon icon-export"></i>
-        </button>
-        <button class="button button-link"
-                placement="top"
-                title=""
                 tooltip="Options"
                 [ngClass]="{'active': chart.showSettings}"
                 (click)="onSettingsToggleClicked()"><i class="icon icon-cog"></i>
@@ -72,4 +60,21 @@
             </div>
         </div>
     </div>
+</div>
+
+<div dropdown [dropup]="true" class="btn-group">
+  <button dropdownToggle class="button dropdown-toggle" type="button"
+    id="exportDropUp" data-toggle="dropdown" aria-haspopup="true"
+    aria-expanded="true">
+    <i class="icon icon-download"></i>
+    Download
+  </button>
+  <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="exportDropUp">
+    <li role="menuitem">
+      <a class="drowdown-item" (click)="onExportClicked()">Download JSON</a>
+    </li>
+    <li role="menuitem">
+      <a class="drowdown-item" (click)="onDownloadImageClicked()">Download Chart</a>
+    </li>
+  </ul>
 </div>

--- a/src/assets/sass/components/_dropdown.scss
+++ b/src/assets/sass/components/_dropdown.scss
@@ -17,6 +17,16 @@
   outline: 0;
 }
 
+.dropup,
+.navbar-fixed-bottom .dropdown {
+  // Different positioning for bottom up menu
+  .dropdown-menu {
+    top: auto;
+    bottom: 100%;
+    margin-bottom: 2px;
+  }
+}
+
 .dropdown-menu {
   position: absolute;
   top: 100%;


### PR DESCRIPTION
## Overview

Move the two chart download buttons into a drop-up below chart.

### Demo

![image](https://user-images.githubusercontent.com/960264/28840553-5764917e-76c5-11e7-921c-386e32943cba.png)


### Notes

Our usage of `ngx-bootstrap` differs somewhat from the documented dropdowns/dropups [here](http://valor-software.com/ngx-bootstrap/#/dropdowns). Notably, this project defines its own bootstrap component styles. It was necessary to add some missing CSS to support drop up (get the menu to position above the button instead of below).


## Testing Instructions

 * Load a chart
 * Should have new dropdown below chart that toggles up
 * Download options in chart should fire download actions (note #180 changes these actions)

Closes #179
