### PR TITLE
Add legend to chart with icons and description

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -19,6 +19,15 @@
             [indicator]="chart.indicator"
             [hover]="isHover">
         </ccl-line-graph>
+        <div class="chart-legend" *ngIf="chartData && chartData.length">
+            <div class="chart-legend-icons">
+                <span><span class="icon-minus chart-legend-line"></span> {{ chartData[0].indicator.default_units }}</span>
+                <span><span class="chart-legend-minmax"></span> Range between min/max of selected models</span>
+            </div>
+            <div class="chart-legend-description">
+                {{ chartData[0].indicator.description }}
+            </div>
+        </div>
         <div class="chart-options">
             <div class="chart-options-body">
                 <nouislider class="chart-options-group"

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -30,6 +30,30 @@ ccl-chart {
     padding-top: 1.5rem;
   }
 
+  .chart-legend {
+    padding: 2rem;
+    padding-top: 0;
+    color: #757575;
+    font-size: 11px;
+
+    .chart-legend-line {
+      color: #1E8CEC;
+    }
+
+    .chart-legend-icons {
+       padding-bottom: 0.5rem;
+    }
+
+    .chart-legend-minmax {
+      color: darken(#EFF4F7, 10%);
+
+      &:before {
+        padding-left: 0.5em;
+        content: '\2B1B'; // unicode large filled square
+      }
+    }
+  }
+
   .chart-options {
     border-top: 1px solid $gray-2;
     margin: 0;

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -37,7 +37,7 @@ ccl-chart {
     font-size: 11px;
 
     .chart-legend-line {
-      color: #1E8CEC;
+      color: $chart-line;
     }
 
     .chart-legend-icons {
@@ -45,7 +45,7 @@ ccl-chart {
     }
 
     .chart-legend-minmax {
-        background-color: darken(#eef4f7, 10%);
+        background-color: darken($chart-minmax, 10%);
         width: 1rem;
         height: 1rem;
         display: inline-block;
@@ -130,7 +130,7 @@ ccl-chart {
 
   .axis {
 
-    color: #757575;
+    color: $chart-axis;
     opacity: .5;
 
     path, line {
@@ -147,7 +147,7 @@ ccl-chart {
   .grid {
 
     line {
-      stroke: #E3E3E3;
+      stroke: $chart-grid;
       stroke-width: 1;
       opacity: 1;
       shape-rendering: crispEdges;
@@ -164,30 +164,30 @@ ccl-chart {
 
   .line {
     fill: none;
-    stroke: #1E8CEC;
+    stroke: $chart-line;
     stroke-width: 2px;
   }
 
   .trendline {
     fill: none;
-    stroke: #D44A34;
+    stroke: $chart-trendline;
     stroke-width: 1px;
     opacity: .7;
   }
 
   .area {
-    fill: #EFF4F7;
+    fill: $chart-minmax;
     opacity: .7;
     z-index: -1;
   }
 
   .min-bar{
-    fill: #41424D;
+    fill: $chart-min-bar;
     opacity: .3;
   }
 
   .max-bar{
-    fill: #F3B32F;
+    fill: $chart-max-bar;
     opacity: .3;
   }
 
@@ -215,7 +215,7 @@ ccl-chart {
   }
 
   .scrubline {
-    stroke: #757575;
+    stroke: $chart-scrubline;
   }
 
   .chart-controls {

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -45,12 +45,11 @@ ccl-chart {
     }
 
     .chart-legend-minmax {
-      color: darken(#EFF4F7, 10%);
-
-      &:before {
-        padding-left: 0.5em;
-        content: '\2B1B'; // unicode large filled square
-      }
+        background-color: darken(#eef4f7, 10%);
+        width: 1rem;
+        height: 1rem;
+        display: inline-block;
+        margin-left: 0.5rem;
     }
   }
 

--- a/src/assets/sass/utils/_variables.scss
+++ b/src/assets/sass/utils/_variables.scss
@@ -205,3 +205,17 @@ $popover-arrow: 8px;
 
 $nav-height: 5rem;
 $nav-width: 20rem;
+
+/* * * *
+ * chart
+ *
+ * * * */
+
+$chart-line: #1e8cec;
+$chart-minmax: #eef4f7;
+$chart-trendline: #d44a34;
+$chart-min-bar: #41424d;
+$chart-max-bar: #f3b32f;
+$chart-axis: #757575;
+$chart-grid: #e3e3e3;
+$chart-scrubline: $chart-axis;


### PR DESCRIPTION
## Overview

This PR adds a legend to indicator charts. The unit is taken from the API response, as is the indicator description. `icon-minus` is used as the key for the line and the unicode character for "large black square" is used as the key for the range area.

### Demo

![climatelegend-scrnshot](https://user-images.githubusercontent.com/539905/28915611-fb85b10e-783f-11e7-8bb2-55a17a065579.png)

### Notes

I wasn't sure if there was a better way to represent the line and the square. Using the icon for "minus" in particular seems to be a bit of a hack, but it seems to match the line weight in the chart. The range area appears pretty light on my screen, so I darkened the color a little bit for the legend. Sometimes the unit could be represented better than the API represents it. For example "degrees F" might be better than "F." As for positioning, there wasn't a lot of context in the screenshot in the issue so I'm not sure how well this matches with what the designers intended.

## Testing Instructions

 * Click different charts
 * See changing description and units

Closes #177