### PR TITLE
Remove second caret in units dropdown

### DIFF
--- a/src/app/lab/components/units-dropdown.component.ts
+++ b/src/app/lab/components/units-dropdown.component.ts
@@ -17,7 +17,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
                 id="unitsDropdown" data-toggle="dropdown" aria-haspopup="true"
                 aria-expanded="true">
                 {{ unit }}
-                <i class="icon-angle-down caret"></i>
+                <i class="caret"></i>
               </button>
               <ul *dropdownMenu class="dropdown-menu" aria-labelledby="unitsDropdown">
                 <li *ngFor="let unit of units">


### PR DESCRIPTION
## Overview

Extra caret on the dropdown 🐰  🐰 


### Demo

Fixed with one caret 🐰 
![screen shot 2017-08-11 at 4 57 52 pm](https://user-images.githubusercontent.com/10568752/29231737-50b90c76-7eb6-11e7-8801-76786e96d433.png)

Closes #200 