### PR TITLE
Update unit labels everywhere upon unit selection

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -16,12 +16,13 @@
             <ccl-line-graph
                 [data]="chartData"
                 [indicator]="chart.indicator"
-                [hover]="isHover">
+                [hover]="isHover"
+                [unit]="unit">
             </ccl-line-graph>
         </div>
         <div class="chart-legend" *ngIf="chartData && chartData.length">
             <div class="chart-legend-icons">
-                <span><span class="icon-minus chart-legend-line"></span> {{ chartData[0].indicator.default_units }}</span>
+                <span><span class="icon-minus chart-legend-line"></span> {{ unit }}</span>
                 <span><span class="chart-legend-minmax"></span> Range between min/max of selected models</span>
             </div>
             <div class="chart-legend-description">

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -32,6 +32,7 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
     @Input() public data: ChartData[];
     @Input() public indicator: Indicator;
     @Input() public hover: Boolean;
+    @Input() public unit: string;
 
     public extractedData: Array<DataPoint>;
 
@@ -297,7 +298,7 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
         this.svg.selectAll('.scrubline').attr('transform', 'translate(' + xPos + ',' + 0 + ')');
 
         // Update scrubber text
-        const labelText = yDatum.toFixed(2) + ' ' + this.data[0]['indicator']['default_units'];
+        const labelText = yDatum.toFixed(2) + ' ' + this.unit;
         const textSVG = D3.select('.scrubber-text.' + this.id).text(labelText);
 
         // Center text


### PR DESCRIPTION
## Overview

The legend and scrubber didn't update accordingly when units were selected.

LMK too if there's other places where this should update, but I don't think there is.

### Demo

kg/m^2 is not the default unit

<img width="627" alt="screen shot 2017-08-25 at 11 38 46 am" src="https://user-images.githubusercontent.com/10568752/29721187-2f3fac1a-898a-11e7-95b4-f63ec7c061f2.png">


## Testing Instructions

`npm run serve`

Closes #216 
