### PR TITLE
Limit edit project to name and description

### DIFF
--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -21,23 +21,25 @@
                         id="project.description"
                         name="project.description"
                         [(ngModel)]="model.project.project_data.description"></textarea>
-                <label for="project.city">Choose a city*</label>
-                <ccl-city-dropdown [projectData]="model.project.project_data" [showIcon]="false"></ccl-city-dropdown>
-                <div class="row">
-                    <div class="column-6 flex-column">
-                        <label for="project.scenario">Scenario*</label>
-                        <ccl-scenario-toggle [projectData]="model.project.project_data"></ccl-scenario-toggle>
-                    </div>
-                    <div class="column-6 flex-column">
-                        <label for="project.models">Models</label>
-                        <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
-                    </div>
-                    <div class="column-6 flex-column" *ngIf="model.project.project_data.charts[0]">
-                        <label for="project.chart.units">Units</label>
-                        <ccl-units-dropdown (unitSelected)="onUnitSelected($event)"
-                                            [units]="model.project.project_data.charts[0].indicator.available_units"
-                                            [unit]="model.project.project_data.charts[0].unit">
-                        </ccl-units-dropdown>
+                <div *ngIf="!edit" class="project-options">
+                    <label for="project.city">Choose a city*</label>
+                    <ccl-city-dropdown [projectData]="model.project.project_data" [showIcon]="false"></ccl-city-dropdown>
+                    <div class="row">
+                        <div class="column-6 flex-column">
+                            <label for="project.scenario">Scenario*</label>
+                            <ccl-scenario-toggle [projectData]="model.project.project_data"></ccl-scenario-toggle>
+                        </div>
+                        <div class="column-6 flex-column">
+                            <label for="project.models">Models</label>
+                            <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
+                        </div>
+                        <div class="column-6 flex-column" *ngIf="model.project.project_data.charts[0]">
+                            <label for="project.chart.units">Units</label>
+                            <ccl-units-dropdown (unitSelected)="onUnitSelected($event)"
+                                                [units]="model.project.project_data.charts[0].indicator.available_units"
+                                                [unit]="model.project.project_data.charts[0].unit">
+                            </ccl-units-dropdown>
+                        </div>
                     </div>
                 </div>
                 <div class="row align-center">
@@ -47,7 +49,7 @@
                             *ngIf="!edit">Create Project</button>
                     <button type="submit"
                             class="button button-primary"
-                            [disabled]="!projectForm.form.valid || !model.project.project_data.city.id || !model.project.project_data.scenario.name"
+                            [disabled]="!projectForm.form.valid"
                             *ngIf="edit">Update Project</button>
                 </div>
             </form>


### PR DESCRIPTION
## Overview

Remove options that don't make sense where they are in edit project settings.

### Demo

![edit-project-cclab](https://user-images.githubusercontent.com/10568752/29727461-f83a33da-89a1-11e7-8f23-32931a6acd10.gif)


### Notes

So that flash stinks when Angular waits for an async request to return to evaluate an *ngIf. To get lab out the door ASAP we chose to minimize work eliminating a minor bug on a feature (projects) that is probably going away soon anyway. 

Closes  #218 
