### PR TITLE
Add historic range control

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { ChartService } from './services/chart.service';
 import { DataExportService } from './services/data-export.service';
 import { ImageExportService } from './services/image-export.service';
 import { ClimateModelService } from './services/climate-model.service';
+import { HistoricRangeService } from './services/historic-range.service';
 import { IndicatorService } from './services/indicator.service';
 import { ScenarioService } from './services/scenario.service';
 import { ProjectService } from './services/project.service';
@@ -116,6 +117,7 @@ const locationStrategyProvider = {
     DataExportService,
     ImageExportService,
     ClimateModelService,
+    HistoricRangeService,
     IndicatorService,
     ScenarioService,
     ProjectService

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { BasetempComponent } from './charts/extra-params-components/basetemp.com
 import { ChartComponent } from './charts/chart.component';
 import { CopyCurlComponent } from './charts/copy-curl.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { HistoricComponent } from './charts/extra-params-components/historic.component';
 import { IndicatorListComponent } from './sidebar/indicator-list.component';
 import { LineGraphComponent } from './charts/line-graph.component';
 import { LoginComponent } from './login/login.component';
@@ -72,6 +73,7 @@ const locationStrategyProvider = {
     BasetempComponent,
     WaveComponent,
     ThresholdComponent,
+    HistoricComponent,
     CopyCurlComponent,
     ChartComponent,
     DashboardComponent,

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -17,6 +17,13 @@
         (basetempParamSelected)="onThresholdSelected($event)">
     </ccl-basetemp-parameters>
 </div>
+<div *ngIf="isHistoricIndicator(chart.indicator.name)" class="chart-options">
+    <ccl-historic-parameters
+        [indicator]="chart.indicator"
+        [extraParams]="extraParams"
+        (historicParamSelected)="onThresholdSelected($event)">
+    </ccl-historic-parameters>
+</div>
 <div class="chart-body">
     <sk-wave [isRunning]="!chartData || ! chartData.length"></sk-wave>
     <div class="chart-graphic" *ngIf="chartData && chartData.length">

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -29,6 +29,7 @@ import { DataExportService } from '../services/data-export.service';
 import { ImageExportService } from '../services/image-export.service';
 
 import { isBasetempIndicator,
+         isHistoricIndicator,
          isThresholdIndicator } from '../charts/extra-params-components/extra-params.constants';
 
 import * as _ from 'lodash';
@@ -69,6 +70,7 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
     public dateRange: number[] = [this.firstYear, this.lastYear];
     public isThresholdIndicator = isThresholdIndicator;
     public isBasetempIndicator = isBasetempIndicator;
+    public isHistoricIndicator = isHistoricIndicator;
     public sliderConfig: any = {
         behaviour: 'drag',
         connect: true,

--- a/src/app/charts/extra-params-components/extra-params.constants.ts
+++ b/src/app/charts/extra-params-components/extra-params.constants.ts
@@ -11,6 +11,11 @@ const basetempIndicatorNames = [
     'heating_degree_days'
 ];
 
+const historicIndicatorNames = [
+    'heat_wave_duration_index',
+    'heat_wave_incidents'
+];
+
 // TODO: concat additional extra parameter names to this array for #203, #204, and #205
 const extraParamsIndicatorNames = thresholdIndicatorNames;
 
@@ -18,15 +23,15 @@ export function isBasetempIndicator(indicatorName: string): boolean {
     return basetempIndicatorNames.indexOf(indicatorName) !== -1;
 }
 
-export function isThresholdIndicator(indicatorName: string): boolean {
-    for (const thresholdName of thresholdIndicatorNames) {
-        if (indicatorName === thresholdName) {
-            return true;
-        }
-    }
-    return false;
+export function isHistoricIndicator(indicatorName: string): boolean {
+    return historicIndicatorNames.indexOf(indicatorName) !== -1;
 }
 
+export function isThresholdIndicator(indicatorName: string): boolean {
+    return thresholdIndicatorNames.indexOf(indicatorName) !== -1;
+}
+
+// TODO: use or remove this function
 export function hasExtraParams(indicatorName: string): boolean {
     for (const extraParamName of extraParamsIndicatorNames) {
         if (indicatorName === extraParamName) {

--- a/src/app/charts/extra-params-components/historic.component.html
+++ b/src/app/charts/extra-params-components/historic.component.html
@@ -1,0 +1,12 @@
+<div class="chart-options-group historic">
+    <form [formGroup]="historicForm" novalidate>
+        <div class="chart-options-body form-group">
+            <span class="optional-parameters-label">Show {{indicator.label | lowercase}} with historic range base year</span>
+                <div class="chart-options-group">
+                    <input type="number"
+                           step="1"
+                           formControlName="historicCtl">
+                </div>
+        </div>
+    </form>
+</div>

--- a/src/app/charts/extra-params-components/historic.component.html
+++ b/src/app/charts/extra-params-components/historic.component.html
@@ -3,9 +3,11 @@
         <div class="chart-options-body form-group">
             <span class="optional-parameters-label">Show {{indicator.label | lowercase}} with historic range base year</span>
                 <div class="chart-options-group">
-                    <input type="number"
-                           step="1"
-                           formControlName="historicCtl">
+                    <select class="form-control chart-options-group" formControlName="historicCtl">
+                        <option *ngFor="let startYear of historicRangeOptions"
+                            [value]="startYear">{{startYear}}
+                        </option>
+                    </select>
                 </div>
         </div>
     </form>

--- a/src/app/charts/extra-params-components/historic.component.ts
+++ b/src/app/charts/extra-params-components/historic.component.ts
@@ -1,0 +1,54 @@
+import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { Indicator } from '../../models/indicator.model';
+import { HistoricIndicatorQueryParams } from '../../models/historic-indicator-query-params.model';
+
+import * as _ from 'lodash';
+
+/*
+ * Historic range params component
+ * Form to allow user to specify the historic range base year param
+ */
+@Component({
+  selector: 'ccl-historic-parameters',
+  templateUrl: './historic.component.html'
+})
+export class HistoricComponent implements AfterViewInit, OnInit {
+
+    @Input() indicator: Indicator;
+    @Input() extraParams: HistoricIndicatorQueryParams;
+    @Output() historicParamSelected = new EventEmitter<HistoricIndicatorQueryParams>();
+
+    historicForm: FormGroup;
+
+    // default form values
+    private defaultHistoric = null;
+
+    constructor(private formBuilder: FormBuilder) {}
+
+    ngOnInit() {
+        // must create form on init instead of constructor to capture @Input values
+        this.createForm();
+    }
+
+    ngAfterViewInit() {
+        // Since valueChanges triggers initially before parent is ready, wait until
+        // parent is ready here and trigger it to draw chart with extra parameters.
+        this.historicParamSelected.emit({
+            'historic_range': this.historicForm.controls.historicCtl.value,
+        });
+    }
+
+    createForm() {
+        this.historicForm = this.formBuilder.group({
+            historicCtl: [this.extraParams.historic_range || this.defaultHistoric],
+        });
+
+        this.historicForm.valueChanges.debounceTime(700).subscribe(form => {
+            this.historicParamSelected.emit({
+                'historic_range': form.historicCtl,
+            });
+        });
+    }
+}

--- a/src/app/charts/extra-params-components/historic.component.ts
+++ b/src/app/charts/extra-params-components/historic.component.ts
@@ -60,6 +60,8 @@ export class HistoricComponent implements AfterViewInit, OnInit {
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
             this.historicRangeOptions = _.map(data, 'start_year');
+            // add empty option, as this is not a required parameter
+            this.historicRangeOptions.unshift('');
         });
     }
 }

--- a/src/app/charts/extra-params-components/historic.component.ts
+++ b/src/app/charts/extra-params-components/historic.component.ts
@@ -1,8 +1,10 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
-import { Indicator } from '../../models/indicator.model';
+import { HistoricRange } from '../../models/historic-range.model';
 import { HistoricIndicatorQueryParams } from '../../models/historic-indicator-query-params.model';
+import { HistoricRangeService } from '../../services/historic-range.service';
+import { Indicator } from '../../models/indicator.model';
 
 import * as _ from 'lodash';
 
@@ -21,15 +23,18 @@ export class HistoricComponent implements AfterViewInit, OnInit {
     @Output() historicParamSelected = new EventEmitter<HistoricIndicatorQueryParams>();
 
     historicForm: FormGroup;
+    public historicRangeOptions: string[] = [];
 
     // default form values
     private defaultHistoric = null;
 
-    constructor(private formBuilder: FormBuilder) {}
+    constructor(private formBuilder: FormBuilder,
+                private historicRangeService: HistoricRangeService) {}
 
     ngOnInit() {
         // must create form on init instead of constructor to capture @Input values
         this.createForm();
+        this.getHistoricRanges();
     }
 
     ngAfterViewInit() {
@@ -49,6 +54,12 @@ export class HistoricComponent implements AfterViewInit, OnInit {
             this.historicParamSelected.emit({
                 'historic_range': form.historicCtl,
             });
+        });
+    }
+
+    getHistoricRanges() {
+        this.historicRangeService.list().subscribe(data => {
+            this.historicRangeOptions = _.map(data, 'start_year');
         });
     }
 }

--- a/src/app/charts/extra-params-components/index.ts
+++ b/src/app/charts/extra-params-components/index.ts
@@ -1,2 +1,3 @@
 export * from './threshold.component';
 export * from './basetemp.component';
+export * from './historic.component';

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -31,7 +31,8 @@ import {
 } from '../lab';
 
 import { ThresholdComponent,
-         BasetempComponent } from '../charts/extra-params-components';
+         BasetempComponent,
+         HistoricComponent } from '../charts/extra-params-components';
 
 import { NavbarComponent } from '../navbar/navbar.component';
 import { DashboardComponent } from '../dashboard/dashboard.component';
@@ -89,7 +90,8 @@ describe('LoginComponent', () => {
                 AddEditProjectComponent, PageNotFoundComponent, SidebarComponent, AppComponent,
                 CityDropdownComponent, ScenarioToggleComponent, ModelModalComponent,
                 UnitsDropdownComponent, ChartComponent, IndicatorListComponent, LineGraphComponent,
-                WaveComponent, ThresholdComponent, CopyCurlComponent, BasetempComponent ],
+                WaveComponent, ThresholdComponent, HistoricComponent, CopyCurlComponent,
+                BasetempComponent ],
             providers: [
                         {provide: AuthService, useValue: authServiceStub}]
         });

--- a/src/app/models/historic-indicator-query-params.model.ts
+++ b/src/app/models/historic-indicator-query-params.model.ts
@@ -1,0 +1,6 @@
+import { ClimateModel } from './climate-model.model';
+import { IndicatorQueryParams } from './indicator-query-params.model';
+
+export interface HistoricIndicatorQueryParams extends IndicatorQueryParams {
+    historic_range: Number;
+}

--- a/src/app/models/historic-range.model.ts
+++ b/src/app/models/historic-range.model.ts
@@ -1,0 +1,4 @@
+export interface HistoricRange {
+    start_year: string;
+    end_year: string;
+}

--- a/src/app/services/historic-range.service.ts
+++ b/src/app/services/historic-range.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+
+import { HistoricRange } from '../models/historic-range.model';
+import { ApiHttp } from '../auth/api-http.service';
+import { apiHost } from '../constants';
+
+/*
+ * Historic Range Service
+ * Returns available historic ranges from API
+ */
+@Injectable()
+export class HistoricRangeService {
+
+    constructor(private apiHttp: ApiHttp) {}
+
+    public list(): Observable<HistoricRange[]> {
+        const url = apiHost + '/api/historic-range/';
+        return this.apiHttp.get(url).map(resp => resp.json() || [] as HistoricRange[]);
+    }
+}

--- a/src/app/services/indicator.service.ts
+++ b/src/app/services/indicator.service.ts
@@ -8,12 +8,14 @@ import { Indicator } from '../models/indicator.model';
 import { IndicatorRequestOpts } from '../models/indicator-request-opts.model';
 import { ThresholdIndicatorQueryParams } from '../models/threshold-indicator-query-params.model';
 import { BasetempIndicatorQueryParams } from '../models/basetemp-indicator-query-params.model';
+import { HistoricIndicatorQueryParams } from '../models/historic-indicator-query-params.model';
 import { IndicatorQueryParams } from '../models/indicator-query-params.model';
 
 import { ApiHttp } from '../auth/api-http.service';
 import { apiHost } from '../constants';
 
 import { isBasetempIndicator,
+         isHistoricIndicator,
          isThresholdIndicator } from '../charts/extra-params-components/extra-params.constants';
 
 /*
@@ -42,10 +44,7 @@ export class IndicatorService {
             searchParams.append('threshold', thresholdParams.threshold.toString());
             searchParams.append('threshold_units', thresholdParams.threshold_units);
             searchParams.append('threshold_comparator', thresholdParams.threshold_comparator);
-        }
-
-        // append extra parameters, if needed
-        if (isBasetempIndicator(options.indicator.name)) {
+        } else if (isBasetempIndicator(options.indicator.name)) {
             const basetempOpts = options.params as BasetempIndicatorQueryParams;
             // abort request if chart is in flux (these parameters are required)
             if (!basetempOpts.basetemp) {
@@ -53,6 +52,11 @@ export class IndicatorService {
             }
             searchParams.append('basetemp', basetempOpts.basetemp.toString());
             searchParams.append('basetemp_units', basetempOpts.basetemp_units);
+        } else if (isHistoricIndicator(options.indicator.name)) {
+            const historicOpts = options.params as HistoricIndicatorQueryParams;
+            if (historicOpts.historic_range) {
+                searchParams.append('historic_range', historicOpts.historic_range.toString());
+            }
         }
 
         if (options.params.years) {


### PR DESCRIPTION
## Overview

Add form for setting historic range, for the two indicators that have only historic range as an extra parameter.


### Demo

![image](https://user-images.githubusercontent.com/960264/29995187-da9b9b32-8fe3-11e7-9527-3a92fd957101.png)


### Notes

~~It would be better to present the available options as a drop-down, as there are only three base years available, by querying for the options from `/api/historic-range/`. As it is, this text field needs a way to give error feedback, as does #230.~~

Updated to query for options and use them in a drop-down. One of the options is empty, as this parameter is not required.

## Testing Instructions

 * Try the control for head wave duration index or heat wave incidents indicators


Closes #203.
