### PR TITLE
Simplify login component test

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,50 +1,19 @@
 import { async } from '@angular/core/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { apiHost } from '../constants';
 import { AuthService } from '../auth/auth.service';
 import { LoginComponent } from './login.component';
 import { LoginForm } from './login-form';
 
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { Ng2AutoCompleteModule } from '../ng2-auto-complete/ng2AutoComplete.module';
-import { UiSwitchModule } from 'ngx-ui-switch/src';
-import { ClipboardModule } from 'ngx-clipboard';
-import { NouisliderModule } from 'ng2-nouislider';
+import { FormsModule } from '@angular/forms';
 
-import {
-    CollapseModule,
-    BsDropdownModule,
-    ModalModule,
-    PaginationModule,
-    TooltipModule,
-    TypeaheadModule } from 'ngx-bootstrap';
-
-import {
-    CityDropdownComponent,
-    ScenarioToggleComponent,
-    ModelModalComponent,
-    UnitsDropdownComponent,
-    LabComponent
-} from '../lab';
-
-import { ThresholdComponent,
-         BasetempComponent,
-         PercentileComponent,
-         HistoricComponent } from '../charts/extra-params-components';
+import { LabComponent } from '../lab';
 
 import { NavbarComponent } from '../navbar/navbar.component';
 import { DashboardComponent } from '../dashboard/dashboard.component';
-import { AddEditProjectComponent } from '../project/add-edit-project.component';
-import { PageNotFoundComponent } from '../http-status/page-not-found/page-not-found.component';
-import { SidebarComponent } from '../sidebar/sidebar.component';
-import { ChartComponent } from '../charts/chart.component';
-import { CopyCurlComponent } from '../charts/copy-curl.component';
-import { IndicatorListComponent } from '../sidebar/indicator-list.component';
-import { LineGraphComponent } from '../charts/line-graph.component';
-import { WaveComponent } from '../ng2-spin-kit/wave.component';
 
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from '../app.component';
@@ -73,28 +42,16 @@ describe('LoginComponent', () => {
         };
 
         TestBed.configureTestingModule({
-            imports: [ FormsModule, Ng2AutoCompleteModule, UiSwitchModule, BrowserModule,
-                       ClipboardModule, NouisliderModule, ReactiveFormsModule,
+            schemas: [ NO_ERRORS_SCHEMA ],
+            imports: [ FormsModule,
 
                 RouterTestingModule.withRoutes([{ path: 'login', component: LoginComponent },
                                                { path: '', component: AppComponent },
                                                { path: 'edit/', component: LoginComponent }]),
 
-                // bootstrap
-                CollapseModule.forRoot(),
-                BsDropdownModule.forRoot(),
-                ModalModule.forRoot(),
-                PaginationModule.forRoot(),
-                TooltipModule.forRoot(),
-                TypeaheadModule.forRoot() ],
-            declarations: [ LoginComponent, NavbarComponent, DashboardComponent, LabComponent,
-                AddEditProjectComponent, PageNotFoundComponent, SidebarComponent, AppComponent,
-                CityDropdownComponent, ScenarioToggleComponent, ModelModalComponent,
-                UnitsDropdownComponent, ChartComponent, IndicatorListComponent, LineGraphComponent,
-                WaveComponent, ThresholdComponent, HistoricComponent, CopyCurlComponent,
-                BasetempComponent, PercentileComponent ],
-            providers: [
-                        {provide: AuthService, useValue: authServiceStub}]
+                ],
+            declarations: [ LoginComponent, NavbarComponent, DashboardComponent, LabComponent, AppComponent ],
+            providers: [{provide: AuthService, useValue: authServiceStub}]
         });
     }));
 


### PR DESCRIPTION
By using `NO_ERRORS_SCHEMA`, only the elements used in the component under test need to be imported.
See: https://angular.io/guide/testing#shallow-component-tests-with-no_errors_schema

## Testing

 * `npm run test` should pass

Closes #241.
