### PR TITLE
Add controls for historic and percentile indicators

### DIFF
--- a/src/app/charts/extra-params-components/extra-params.constants.ts
+++ b/src/app/charts/extra-params-components/extra-params.constants.ts
@@ -13,16 +13,19 @@ const basetempIndicatorNames = [
 
 const historicIndicatorNames = [
     'heat_wave_duration_index',
-    'heat_wave_incidents'
+    'heat_wave_incidents',
+    'extreme_heat_events',
+    'extreme_precipitation_events'
 ];
 
 const percentileIndicatorNames = [
     'percentile_high_temperature',
     'percentile_low_temperature',
-    'percentile_precipitation'
+    'percentile_precipitation',
+    'extreme_heat_events',
+    'extreme_precipitation_events'
 ];
 
-// TODO: concat additional extra parameter names to this array for #205
 const extraParamsIndicatorNames = [].concat(thresholdIndicatorNames,
                                             percentileIndicatorNames,
                                             historicIndicatorNames);


### PR DESCRIPTION
## Overview

Add extra parameter controls for the two indicators that take both historic range and percentile as extra parameters.

Simply stacks the two controls on top of each other.


### Demo

![image](https://user-images.githubusercontent.com/960264/30116926-11e78414-931f-11e7-8160-2e729a3aff4d.png)


### Notes

Would be prettier and less repetitive to create an additional control with different text and both controls on one line. Went with this for now to get something implemented quickly.


## Testing Instructions

 * View chart for either extreme heat or extreme precipitation
 * Check both controls work
 
Closes #205 
