### PR TITLE
Add postinstall step to rebuild node-sass

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,8 +22,8 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include test case, and expected output
 
 ## Checklist
-- [ ] `npm run serve` clean?
-- [ ] `npm run build:prod` clean?
-- [ ] `npm run lint` clean?
+- [ ] `yarn run serve` clean?
+- [ ] `yarn run build:prod` clean?
+- [ ] `yarn run lint` clean?
 
 Closes|Fixes #XXX

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "ng test",
     "lint": "ng lint --type-check",
     "lint:ci": "ng lint --type-check --format checkstyle > jenkins/violations.xml",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "postinstall": "npm rebuild node-sass"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Overview

Fixes CI build issues caused by sass/node-sass#1579.

Also, update PR template to use `yarn` commands.


### Demo

~Optional. Screenshots, `curl` examples, etc.~


### Notes

~Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.~


## Testing Instructions
```bash
# delete node_modules
docker-compose run --rm --entrypoint "/bin/bash -c" app "rm -rf node_modules/*"

# reinstall node_modules
docker-compose run --rm app install

# Make sure node-sass binding is present
docker-compose run --rm --entrypoint "/bin/bash -c" app "ls -l node_modules/node-sass/vendor/linux-x64-51/binding.node"
-rw-r--r-- 1 root root 3117236 Sep  7 14:13 node_modules/node-sass/vendor/linux-x64-51/binding.node
```
 * See [Jenkins output](http://urbanappsci.internal.azavea.com/job/azavea/job/climate-change-lab/view/change-requests/job/PR-248/1/console)

## Checklist
- [x] `npm run serve` clean?
- [x] `npm run build:prod` clean?
- [x] `npm run lint` clean?

Closes|Fixes #XXX
