### PR TITLE
Log out on async request if token not set

### DIFF
--- a/src/app/auth/api-http.service.ts
+++ b/src/app/auth/api-http.service.ts
@@ -40,13 +40,18 @@ export class ApiHttp extends Http {
     }
 
     private appendAPIHeaders(options?: RequestOptionsArgs): RequestOptionsArgs {
+        const token = this.authService.getToken();
+        if (!token) {
+            this.authService.logout();
+            return;
+        }
         if (options == null) {
             options = new RequestOptions();
         }
         if (options.headers == null) {
             options.headers = new Headers();
         }
-        options.headers.set('Authorization', 'Token ' + this.authService.getToken());
+        options.headers.set('Authorization', 'Token ' + token);
         options.headers.set('Accept', 'application/json');
 
         if (options.search == null) {


### PR DESCRIPTION
## Overview

Log out and redirect to login page on async request if auth token not set.

Note that app already redirects to login on a routing request by using `auth.guard`; this is to handle unauthenticated async requests.


## Testing Instructions

 * Sign in and load a graph
 * Delete `localstorage` for the domain
 * Initiate an async request by changing the indicator or request parameters
 * Should redirect to log in again

Fixes #232.
