### PR TITLE
Redirect to login on auth error response

### DIFF
--- a/src/app/auth/api-http.service.ts
+++ b/src/app/auth/api-http.service.ts
@@ -20,7 +20,12 @@ export class ApiHttp extends Http {
     }
 
     request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
-        return super.request(url, this.appendAPIHeaders(options));
+        return super.request(url, this.appendAPIHeaders(options)).catch((error: Response) => {
+            if (error.status === 401 || error.status === 403) {
+                this.authService.logout();
+            }
+            return Observable.throw(error);
+        });
     }
 
     get(url: string, options?: RequestOptionsArgs): Observable<Response> {


### PR DESCRIPTION
## Overview

If server returns 401 or 403 auth error, log out and redirect to log in again.


### Notes

Handling the error in each HTTP method is not necessary, as each of them call `request` in turn ([source here](https://github.com/angular/angular/blob/4.4.2/packages/http/src/http.ts#L42-L185)).


## Testing Instructions

 * Log in to the site
 * With the server still running, change the `apiHost` in `src/app/constants.ts`
 * When page live reloads, it should redirect to the login page with a 401 error in the console

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Fixes #259.
