### PR TITLE
Feature/kak/dataset selector#258

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import {
   CityDropdownComponent,
   LabComponent,
   ModelModalComponent,
+  DatasetToggleComponent,
   ScenarioToggleComponent,
   UnitsDropdownComponent } from './lab';
 
@@ -56,6 +57,7 @@ import { AuthService } from './auth/auth.service';
 import { AuthGuard } from './auth/auth.guard';
 import { ChartService } from './services/chart.service';
 import { DataExportService } from './services/data-export.service';
+import { DatasetService } from './services/dataset.service';
 import { ImageExportService } from './services/image-export.service';
 import { ClimateModelService } from './services/climate-model.service';
 import { HistoricRangeService } from './services/historic-range.service';
@@ -89,6 +91,7 @@ const locationStrategyProvider = {
     PageNotFoundComponent,
     LoginComponent,
     AddEditProjectComponent,
+    DatasetToggleComponent,
     ScenarioToggleComponent,
     ModelModalComponent,
     CityDropdownComponent,
@@ -118,6 +121,7 @@ const locationStrategyProvider = {
     AuthGuard,
     ChartService,
     DataExportService,
+    DatasetService,
     ImageExportService,
     ClimateModelService,
     HistoricRangeService,

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -17,6 +17,7 @@ import { Chart } from '../models/chart.model';
 import { ChartData } from '../models/chart-data.model';
 import { City } from '../models/city.model';
 import { ClimateModel } from '../models/climate-model.model';
+import { Dataset } from '../models/dataset.model';
 import { IndicatorRequestOpts } from '../models/indicator-request-opts.model';
 import { IndicatorQueryParams } from '../models/indicator-query-params.model';
 import { Scenario } from '../models/scenario.model';
@@ -49,6 +50,7 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
     @Output() onExtraParamsChanged = new EventEmitter<IndicatorQueryParams>();
 
     @Input() chart: Chart;
+    @Input() dataset: Dataset;
     @Input() scenario: Scenario;
     @Input() models: ClimateModel[];
     @Input() city: City;
@@ -115,8 +117,8 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
     }
 
     ngOnChanges($event) {
-        if (!this.scenario || !this.city || !this.models) { return; }
         // happens if different chart selected
+        if (!this.scenario || !this.city || !this.models || !this.dataset) { return; }
         this.updateChart($event);
     }
 
@@ -130,7 +132,8 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
         this.rawChartData = [];
 
         let params: IndicatorQueryParams = {
-            climateModels: this.models,
+            climateModels: _.filter(this.models, model => model.enabled),
+            dataset: this.dataset.name,
             unit: this.unit || this.chart.indicator.default_units,
             time_aggregation: TimeAggParam.Yearly
         }
@@ -184,6 +187,7 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
         const fileName: string = [
             this.chart.indicator.name,
             this.city.properties.name,
+            this.dataset.name,
             this.scenario.name
         ].join('_');
 

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -20,6 +20,7 @@ import * as _ from 'lodash';
     <div class="dropdown button-group">
         <button class="button"
                *ngFor="let s of datasets"
+               [disabled]="!isValidDataset(s)"
                [ngClass]="{'active': s.name === projectData.dataset.name}"
                (click)="onDatasetClicked(s, $event)">
             {{ s.name }}
@@ -49,6 +50,11 @@ export class DatasetToggleComponent implements OnInit {
         if (event) {
             event.preventDefault();
         }
+    }
+
+    // helper that checks if a given dataset is available for the currently selected city
+    public isValidDataset(dataset: Dataset): boolean {
+        return _.includes(this.projectData.city.properties.datasets, dataset.name);
     }
 
     private getDatasets() {

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -57,15 +57,11 @@ export class DatasetToggleComponent implements OnInit {
 
     // set to default, or first valid option for the selected city
     private selectDefaultDataset() {
-        let dataset = this.datasets.find((s) => {
-            return s.name === this.DEFAULT_DATASET_NAME;
-        });
+        let dataset = this.datasets.find(s => s.name === this.DEFAULT_DATASET_NAME);
 
         // if the standard default dataset is not valid, use first valid option
         if (!this.isValidDataset(dataset)) {
-            dataset = this.datasets.find((s) => {
-                return this.isValidDataset(s);
-            });
+            dataset = this.datasets.find(s => this.isValidDataset(s));
         }
 
         this.onDatasetSelected(dataset);

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -54,6 +54,9 @@ export class DatasetToggleComponent implements OnInit {
 
     // helper that checks if a given dataset is available for the currently selected city
     public isValidDataset(dataset: Dataset): boolean {
+        if (!this.projectData.city.properties) {
+            return true; // city properties may be undefined in form to create new project
+        }
         return _.includes(this.projectData.city.properties.datasets, dataset.name);
     }
 

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -22,7 +22,7 @@ import * as _ from 'lodash';
                *ngFor="let s of datasets"
                [disabled]="!isValidDataset(s)"
                [ngClass]="{'active': s.name === projectData.dataset.name}"
-               (click)="onDatasetClicked(s, $event)">
+               (click)="onDatasetSelected(s, $event)">
             {{ s.name }}
         </button>
     </div>
@@ -41,7 +41,7 @@ export class DatasetToggleComponent implements OnInit {
         this.getDatasets();
     }
 
-    public onDatasetClicked(dataset: Dataset, event?: Event) {
+    public onDatasetSelected(dataset: Dataset, event?: Event) {
         this.projectData.dataset = dataset;
         this.projectData.models.forEach(model => {
             model.enabled = _.includes(dataset.models, model.name);
@@ -66,7 +66,7 @@ export class DatasetToggleComponent implements OnInit {
 
             // Set a default for the project if none is set
             if (!this.projectData.dataset) {
-                this.onDatasetClicked(this.datasets.find((s) => {
+                this.onDatasetSelected(this.datasets.find((s) => {
                     return s.name === this.DEFAULT_DATASET_NAME;
                 }));
             }

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -4,6 +4,8 @@ import { Dataset } from '../../models/dataset.model';
 import { ProjectData } from '../../models/project-data.model';
 import { DatasetService } from '../../services/dataset.service';
 
+import * as _ from 'lodash';
+
 /*  Dataset Toggle Component
 
     -- Requires project input
@@ -40,6 +42,10 @@ export class DatasetToggleComponent implements OnInit {
 
     public onDatasetClicked(dataset: Dataset, event?: Event) {
         this.projectData.dataset = dataset;
+        this.projectData.models.forEach(model => {
+            model.enabled = _.includes(dataset.models, model.name);
+        });
+
         if (event) {
             event.preventDefault();
         }

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+import { Dataset } from '../../models/dataset.model';
+import { ProjectData } from '../../models/project-data.model';
+import { DatasetService } from '../../services/dataset.service';
+
+/*  Dataset Toggle Component
+
+    -- Requires project input
+    Expected use:
+        <ccl-dataset-toggle
+            [projectData]="your_project.project_data">
+*/
+
+@Component({
+  selector: 'ccl-dataset-toggle',
+  template: `
+    <div class="dropdown button-group">
+        <button class="button"
+               *ngFor="let s of datasets"
+               [ngClass]="{'active': s.name === projectData.dataset.name}"
+               (click)="onDatasetClicked(s, $event)">
+            {{ s.name }}
+        </button>
+    </div>
+  `
+
+})
+export class DatasetToggleComponent implements OnInit {
+
+    @Input() projectData: ProjectData;
+    public datasets: Dataset[] = [];
+    private DEFAULT_DATASET_NAME = 'NEX-GDDP';
+
+    constructor(private datasetService: DatasetService) {}
+
+    ngOnInit() {
+        this.getDatasets();
+    }
+
+    public onDatasetClicked(dataset: Dataset, event?: Event) {
+        this.projectData.dataset = dataset;
+        if (event) {
+            event.preventDefault();
+        }
+    }
+
+    private getDatasets() {
+        this.datasetService.list().subscribe(data => {
+            this.datasets = data;
+
+            // Set a default for the project if none is set
+            if (!this.projectData.dataset) {
+                this.onDatasetClicked(this.datasets.find((s) => {
+                    return s.name === this.DEFAULT_DATASET_NAME;
+                }));
+            }
+        });
+    }
+}

--- a/src/app/lab/components/model-modal.component.html
+++ b/src/app/lab/components/model-modal.component.html
@@ -30,6 +30,7 @@
             <input type="checkbox"
                    name="modelCheckbox"
                    value="value"
+                   [disabled]="!climateModel.enabled"
                    [(ngModel)]="climateModel.selected">
             {{ climateModel.name }}
           </label>

--- a/src/app/lab/components/model-modal.component.html
+++ b/src/app/lab/components/model-modal.component.html
@@ -13,6 +13,7 @@
      aria-hidden="true"
      bsModal #smModal="bs-modal"
      [config]="{backdrop: 'static'}"
+     (onShow)="modalShow()"
      (onHide)="modalHide()">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">

--- a/src/app/lab/components/model-modal.component.ts
+++ b/src/app/lab/components/model-modal.component.ts
@@ -103,7 +103,7 @@ export class ModelModalComponent implements OnInit {
     }
 
     private updateButtonText() {
-        this.buttonText = this.projectData.models.length === this.climateModels.length ?
-            'All available models' : 'Subset of models';
+        this.buttonText = this.projectData.models.length ===
+            this.projectData.dataset.models.length ? 'All available models' : 'Subset of models';
     }
 }

--- a/src/app/lab/components/model-modal.component.ts
+++ b/src/app/lab/components/model-modal.component.ts
@@ -55,6 +55,7 @@ export class ModelModalComponent implements OnInit {
     }
 
     public updateProjectClimateModels() {
+        this.disableClimateModels();
         this.projectData.models = this.filterSelectedClimateModels();
         this.updateButtonText();
     }
@@ -79,7 +80,8 @@ export class ModelModalComponent implements OnInit {
             // Initialize 'selected' attributes with models in project
             if (this.projectData.models.length === 0) {
                 this.selectAllClimateModels();
-            } else {
+            } else if (this.projectData.dataset) {
+                // dataset may be undefined for project if in form to create new project
                 this.projectData.models.forEach(projectModel => {
                     this.climateModels.forEach(model => {
                         if (projectModel.name === model.name) {
@@ -89,7 +91,6 @@ export class ModelModalComponent implements OnInit {
                 });
             }
 
-            this.disableClimateModels();
             this.updateProjectClimateModels();
         });
     }

--- a/src/app/lab/components/model-modal.component.ts
+++ b/src/app/lab/components/model-modal.component.ts
@@ -6,6 +6,8 @@ import { ClimateModel } from '../../models/climate-model.model';
 import { ProjectData } from '../../models/project-data.model';
 import { ClimateModelService } from '../../services/climate-model.service';
 
+import * as _ from 'lodash';
+
 /*  Model Modal Component
     -- Requires project input
     -- Emits selected model
@@ -37,6 +39,13 @@ export class ModelModalComponent implements OnInit {
         this.climateModels.forEach(model => model.selected = false);
     }
 
+    // disable models not valid for the project datset
+    public disableClimateModels() {
+        this.climateModels.forEach(model => {
+            model.enabled = _.includes(this.projectData.dataset.models, model.name);
+        });
+    }
+
     public isModalUpdateButtonDisabled() {
         return this.climateModels.filter(model => model.selected).length === 0;
     }
@@ -58,8 +67,8 @@ export class ModelModalComponent implements OnInit {
         this.updateProjectClimateModels();
     }
 
-    private filterSelectedClimateModels(isSelected: boolean = true) {
-        return this.climateModels.filter(model => model.selected === isSelected);
+    private filterSelectedClimateModels() {
+        return this.climateModels.filter(model => model.selected && model.enabled);
     }
 
     // subscribe to list of available models from API endpoint
@@ -70,7 +79,6 @@ export class ModelModalComponent implements OnInit {
             // Initialize 'selected' attributes with models in project
             if (this.projectData.models.length === 0) {
                 this.selectAllClimateModels();
-                this.updateProjectClimateModels();
             } else {
                 this.projectData.models.forEach(projectModel => {
                     this.climateModels.forEach(model => {
@@ -80,7 +88,9 @@ export class ModelModalComponent implements OnInit {
                     });
                 });
             }
-            this.updateButtonText();
+
+            this.disableClimateModels();
+            this.updateProjectClimateModels();
         });
     }
 

--- a/src/app/lab/components/model-modal.component.ts
+++ b/src/app/lab/components/model-modal.component.ts
@@ -41,6 +41,9 @@ export class ModelModalComponent implements OnInit {
 
     // disable models not valid for the project datset
     public disableClimateModels() {
+        if (!this.projectData.dataset) {
+            return;
+        }
         this.climateModels.forEach(model => {
             model.enabled = _.includes(this.projectData.dataset.models, model.name);
         });
@@ -58,6 +61,10 @@ export class ModelModalComponent implements OnInit {
         this.disableClimateModels();
         this.projectData.models = this.filterSelectedClimateModels();
         this.updateButtonText();
+    }
+
+    public modalShow() {
+        this.updateProjectClimateModels();
     }
 
     public modalHide() {

--- a/src/app/lab/index.ts
+++ b/src/app/lab/index.ts
@@ -1,4 +1,5 @@
 export * from './lab.component';
+export * from './components/dataset-toggle.component';
 export * from './components/scenario-toggle.component';
 export * from './components/model-modal.component';
 export * from './components/city-dropdown.component';

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -46,6 +46,7 @@
             <ccl-chart [chart]="project.project_data.charts[0]"
                        [city]="project.project_data.city"
                        [models]="project.project_data.models"
+                       [dataset]="project.project_data.dataset"
                        [scenario]="project.project_data.scenario"
                        [unit]="project.project_data.charts[0].unit"
                        [extraParams]="project.project_data.extraParams"

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -19,6 +19,11 @@
               <label>Scenario</label>
               <ccl-scenario-toggle [projectData]="project.project_data"></ccl-scenario-toggle>
             </div>
+            <!-- dataset selector -->
+            <div class="control-group">
+              <label>Dataset</label>
+              <ccl-dataset-toggle [projectData]="project.project_data"></ccl-dataset-toggle>
+            </div>
             <!-- climate model selector -->
             <div class="control-group">
               <label>Models</label>

--- a/src/app/models/city.model.ts
+++ b/src/app/models/city.model.ts
@@ -1,10 +1,11 @@
 import { Feature, Point } from 'geojson';
 
 export interface CityProperties {
-    name: String;
-    admin: String;
-    population?: Number;
-    map_cell: Point;
+    name: string;
+    admin: string;
+    population?: number;
+    datasets: string[];
+    region: number;
 }
 
 export interface City {

--- a/src/app/models/climate-model.model.ts
+++ b/src/app/models/climate-model.model.ts
@@ -2,6 +2,7 @@ export interface ClimateModel {
     name: string;
     description: string;
     base_time: string;
+    datasets: string[];
     enabled?: boolean;
     selected?: boolean;
 }

--- a/src/app/models/climate-model.model.ts
+++ b/src/app/models/climate-model.model.ts
@@ -2,5 +2,6 @@ export interface ClimateModel {
     name: string;
     description: string;
     base_time: string;
+    enabled?: boolean;
     selected?: boolean;
 }

--- a/src/app/models/dataset.model.ts
+++ b/src/app/models/dataset.model.ts
@@ -1,0 +1,7 @@
+export interface Dataset {
+    name: string;
+    label: string;
+    description: string;
+    url: string;
+    models: string[];
+}

--- a/src/app/models/indicator-query-params.model.ts
+++ b/src/app/models/indicator-query-params.model.ts
@@ -3,6 +3,7 @@ import { TimeAggParam } from './time-agg-param.enum';
 
 export interface IndicatorQueryParams {
     climateModels?: ClimateModel[];
+    dataset?: string;
     years?: string[];
     time_aggregation?: TimeAggParam;
     agg?: string;

--- a/src/app/models/project-data.model.ts
+++ b/src/app/models/project-data.model.ts
@@ -1,12 +1,14 @@
 import { City } from './city.model';
 import { Chart } from './chart.model';
 import { ClimateModel } from './climate-model.model';
+import { Dataset } from './dataset.model';
 import { Scenario } from './scenario.model';
 
 export class ProjectData {
     name: string;
     description: string;
     city: City;
+    dataset: Dataset;
     scenario: Scenario;
     models: ClimateModel[] = [];
     charts: Chart[] = [];
@@ -26,6 +28,7 @@ export class ProjectData {
             description: this.description,
             city: this.city,
             scenario: this.scenario,
+            dataset: this.dataset,
             models: this.models,
             charts: this.charts,
             extraParams: this.extraParams

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -33,13 +33,6 @@
                             <label for="project.models">Models</label>
                             <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
                         </div>
-                        <div class="column-6 flex-column" *ngIf="model.project.project_data.charts[0]">
-                            <label for="project.chart.units">Units</label>
-                            <ccl-units-dropdown (unitSelected)="onUnitSelected($event)"
-                                                [units]="model.project.project_data.charts[0].indicator.available_units"
-                                                [unit]="model.project.project_data.charts[0].unit">
-                            </ccl-units-dropdown>
-                        </div>
                     </div>
                 </div>
                 <div class="row align-center">

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -44,7 +44,8 @@
                 <div class="row align-center">
                     <button type="submit"
                             class="button button-primary"
-                            [disabled]="!projectForm.form.valid || !model.project.project_data.city.id || !model.project.project_data.scenario.name"
+                            [disabled]="!projectForm.form.valid || !model.project.project_data.city.id || !model.project.project_data.scenario.name ||
+                            !model.project.project_data.dataset.name"
                             *ngIf="!edit">Create Project</button>
                     <button type="submit"
                             class="button button-primary"

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -25,11 +25,15 @@
                     <label for="project.city">Choose a city*</label>
                     <ccl-city-dropdown [projectData]="model.project.project_data" [showIcon]="false"></ccl-city-dropdown>
                     <div class="row">
-                        <div class="column-6 flex-column">
+                        <div class="column-4 flex-column">
                             <label for="project.scenario">Scenario*</label>
                             <ccl-scenario-toggle [projectData]="model.project.project_data"></ccl-scenario-toggle>
                         </div>
-                        <div class="column-6 flex-column">
+                        <div class="column-4 flex-column">
+                            <label for="project.scenario">Dataset*</label>
+                            <ccl-dataset-toggle [projectData]="model.project.project_data"></ccl-dataset-toggle>
+                        </div>
+                        <div class="column-4 flex-column">
                             <label for="project.models">Models</label>
                             <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
                         </div>

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -31,7 +31,9 @@
                         </div>
                         <div class="column-4 flex-column">
                             <label for="project.scenario">Dataset*</label>
-                            <ccl-dataset-toggle [projectData]="model.project.project_data"></ccl-dataset-toggle>
+                            <ccl-dataset-toggle
+                                [projectData]="model.project.project_data">
+                            </ccl-dataset-toggle>
                         </div>
                         <div class="column-4 flex-column">
                             <label for="project.models">Models</label>

--- a/src/app/services/dataset.service.ts
+++ b/src/app/services/dataset.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+
+import { Dataset } from '../models/dataset.model';
+import { ApiHttp } from '../auth/api-http.service';
+import { apiHost } from '../constants';
+
+/*
+ * Dataset Service
+ * Returns datasets from API
+ */
+@Injectable()
+export class DatasetService {
+
+    constructor(private apiHttp: ApiHttp) {}
+
+    public list(): Observable<Dataset[]> {
+        const url = apiHost + '/api/dataset/';
+        return this.apiHttp.get(url).map(resp => resp.json() || [] as Dataset[]);
+    }
+}

--- a/src/app/services/indicator.service.ts
+++ b/src/app/services/indicator.service.ts
@@ -81,6 +81,9 @@ export class IndicatorService {
         if (options.params.unit) {
             searchParams.append('units', options.params.unit);
         }
+        if (options.params.dataset) {
+            searchParams.append('dataset', options.params.dataset);
+        }
 
         const requestOptions = new RequestOptions({ search: searchParams });
         return this.apiHttp.get(url, requestOptions).map(resp => {


### PR DESCRIPTION
## Overview

Adds a `dataset` selector.

Sends `dataset` query parameter. Filters `models` list to those valid for given `dataset`. Invalid, selected models remain selected but its checkbox control is disabled in the modal. Disables `dataset` options invalid for the current city selection.

Depends on [companion PR for the project schema](azavea/climate-change-api#701).

### Demo

![image](https://user-images.githubusercontent.com/960264/30829709-93278020-a20f-11e7-830d-41755a48cd2e.png)

![image](https://user-images.githubusercontent.com/960264/30829775-c57ae09e-a20f-11e7-9a02-8fbeb09f77ee.png)


### Notes

If a change in the selected city causes the `dataset` for the project to become invalid, the `dataset` will be changed to the default (NEX-GDDP) if that is valid, or the first valid option if not.

Currently there is no 'LOCA' data available for the development instance. To fake the 'LOCA' dataset being valid for a city, you can create a `ClimateDataCityCell` without data in the API project database:

 * `vagrant ssh`
 * `./scripts/manage shell_plus`

Then in the Django shell:
```python
# get a city
city = City.objects.first()

# create a LOCA map cell for the city
new_cell = ClimateDataCityCell(city=city, map_cell=city.map_cell_set.first(), dataset=ClimateDataset.objects.get(name='LOCA'))

new_cell.save()

# should now have two map cells for city, one for each dataset
city.map_cell_set.all()
```

Note that since there will be no actual data loaded, selecting 'LOCA' in the Lab will result in a blank chart with some chart-related console errors (about `trailing garbage` and `toFixed`). But, this should be sufficient for testing UI component interactions.

## Testing Instructions

 * Check out the [companion API PR](https://github.com/azavea/climate-change-api/pull/701) and start its server
 * Edit `apiHost` in `src/app/constants.ts` to point to 'http://localhost:8080'
 * `yarn run serve`
 * Try [creating a new project](http://localhost:4200/#/new), checking fields cross-update as appropriate
 * Try modifying project fields (city/dataset/models) from charts page, checking updates

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?


Closes #258 
Closes #257
Closes #262 


