### PR TITLE
Always display units dropdown

### DIFF
--- a/src/app/lab/components/units-dropdown.component.ts
+++ b/src/app/lab/components/units-dropdown.component.ts
@@ -16,7 +16,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
               <button dropdownToggle class="button dropdown-toggle" type="button"
                 id="unitsDropdown" data-toggle="dropdown" aria-haspopup="true"
                 aria-expanded="true">
-                {{ unit }}
+                {{ unit || 'N/A' }}
                 <i class="caret"></i>
               </button>
               <ul *dropdownMenu class="dropdown-menu" aria-labelledby="unitsDropdown">

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -32,9 +32,10 @@
             <!-- units selector, only show if indicator selected -->
             <div class="control-group">
               <label>Units</label>
-              <ccl-units-dropdown *ngIf="project.project_data.charts[0]"
-                                  [units]="project.project_data.charts[0].indicator.available_units"
-                                  [unit]="project.project_data.charts[0].unit"
+              <ccl-units-dropdown [units]="project.project_data.charts[0] ?
+                                  project.project_data.charts[0].indicator.available_units: ['N/A']"
+                                  [unit]="project.project_data.charts[0] ?
+                                  project.project_data.charts[0].unit: 'N/A'"
                                   (unitSelected)="onUnitSelected($event)">
               </ccl-units-dropdown>
             </div>

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -35,7 +35,7 @@
               <ccl-units-dropdown [units]="project.project_data.charts[0] ?
                                   project.project_data.charts[0].indicator.available_units: ['N/A']"
                                   [unit]="project.project_data.charts[0] ?
-                                  project.project_data.charts[0].unit: 'N/A'"
+                                  project.project_data.charts[0].unit: ''"
                                   (unitSelected)="onUnitSelected($event)">
               </ccl-units-dropdown>
             </div>


### PR DESCRIPTION
## Overview

If no chart has been selected yet for a project, display the header units selector, with a single "N/A" dummy option.

Before, selector label would display but not the component below it. Added 'N/A' option since an empty, blank selector looked strange, and users might not recognize immediately that it is tied to the selected  indicator options.


### Demo

![image](https://user-images.githubusercontent.com/960264/31192456-4a5f1aea-a90f-11e7-8da8-9fe7f162c4de.png)


## Testing Instructions

 * Create a new project
 * Before selecting a chart, should see dropdown under units label
 * No console errors

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Fixes #261 

