### PR TITLE
Style and HTML changes made to match API better

### DIFF
--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -7,12 +7,12 @@
     </h1>
   </div>
   <div class="nav-right">
+    <a class="button button-link" href="{{ apiHost }}/accounts/api/">API</a>
+    <a class="button button-link active" [routerLink]="['/']">Lab</a>
     <div class="dropdown"
          *ngIf="authService.isAuthenticated()"
          dropdown
          [(isOpen)]="isSettingsDropdownOpen">
-      <a class="button button-link" href="{{ apiHost }}/accounts/api/">API</a>
-      <a class="button button-link active" [routerLink]="['/']">Lab</a>
       <button id="settings-dropdown" type="button" class="button button-link" dropdownToggle>
         {{ authService.getEmail() }}
         <i [ngClass]="{'icon-angle-down': !isSettingsDropdownOpen, 'icon-angle-up': isSettingsDropdownOpen}"></i>

--- a/src/assets/sass/components/_navbar.scss
+++ b/src/assets/sass/components/_navbar.scss
@@ -5,21 +5,40 @@ nav {
 .nav-primary {
   background-color: $color-header;
   height: 100%;
-  color: #fff;
-  height: $nav-height-main;
+  display: flex;
+  justify-content: space-between;
 
   & > .nav-left {
-    float: left;
     padding: 0.6rem 1.5rem 0;
   }
 
   & > .nav-right {
-    float: right;
-    padding: 0.7rem 1.5rem 0;
+    display: flex;
+    align-items: center;
 
-    .active {
-      border-bottom: 2px solid #fff;
-      font-weight: bold;
+    > a {
+      color: #fff;
+      position: relative; 
+      margin: 0 1.5rem;
+      padding: 1.5rem 0;
+
+      &.active {
+        font-weight: bold;
+      }
+
+      &.active:before {
+        content: "";
+        position: absolute;
+        height: 4px;
+        width: 100%;
+        background: white;
+        top: 0;
+        left: 0;
+      }
+
+      &:hover {
+        color: darken(white, 10%);
+      }
     }
   }
 }
@@ -51,6 +70,7 @@ nav {
   .dropdown {
     display: block;
     height: 100%;
+
     & > .button {
       height: 4rem;
       border-radius: 0;
@@ -63,6 +83,10 @@ nav {
 
       &.active {
         background-color: #E3E3E3;
+      }
+      
+      &:hover {
+        color: darken(white, 10%);
       }
     }
   }

--- a/src/assets/sass/pages/_labs.scss
+++ b/src/assets/sass/pages/_labs.scss
@@ -44,12 +44,55 @@ nav {
   .dropdown-menu {
     border: 1px solid #cccccc;
     margin: 0 0 0 -1px;
-    border-radius: 0;
+    min-width: 160px;
+    
+    li {
+      border-bottom: none;
+      margin-top: 0;
+      margin-bottom: 0;
+
+      a {
+        padding: 7px 20px;
+      }
+
+      &:not(:last-child) {
+        a {
+          border-bottom: none;
+        }
+      }
+    }
+
     & > .active > a {
       font-weight: 800;
     }
-  }
+    // Arrow on top of dropdown menu
+    &:before {
+      content: "";
+      display: block;
+      position: absolute;
+      height: 10px;
+      width: 10px;
+      background-color: white;
+      transform: rotate(45deg);
+      top: -5px;
+      right: 12px;
+      outline: 1px solid #ccc;
+      z-index: -1;
+    }
 
+    // A white box to cover the outline of the arrow
+    &:after {
+      content: "";
+      display: block;
+      position: absolute;
+      height: 10px;
+      width: 22px;
+      background-color: white;
+      top: 0;
+      right: 6px;
+      z-index: -1;
+    }
+  }
 }
 
 .logo {


### PR DESCRIPTION
## Overview

Addresses some of the style changes proposed by @CloudNiner in #277 to match the universal header on Climate API. There are still some discrepancies, but it should be less jarring to switch between the two. As with the changes to the Climate API header, I imagine that @jfrankl will have changes for this.

### Demo
![screen shot 2017-10-06 at 4 18 11 pm](https://user-images.githubusercontent.com/5672295/31296983-5031f6e6-aab2-11e7-9e61-354a1d8b6c5b.png)



