### PR TITLE
Feature/kak/update precip units#276

### DIFF
--- a/src/app/charts/extra-params-components/extra-params.constants.ts
+++ b/src/app/charts/extra-params-components/extra-params.constants.ts
@@ -37,9 +37,9 @@ export const TemperatureUnits: any[] = [
  ];
 
 export const PrecipitationUnits: any[] = [
-    {'key': 'mm', 'label': 'millimeters'},
-    {'key': 'in', 'label': 'inches'},
-    {'key': 'kg/m^2', 'label': 'kg/m^2'}
+    {'key': 'mm/day', 'label': 'millimeters per day'},
+    {'key': 'in/day', 'label': 'inches per day'},
+    {'key': 'kg/m^2/s', 'label': 'kg/m^2/s'}
 ];
 
 export function isBasetempIndicator(indicatorName: string): boolean {

--- a/src/app/charts/extra-params-components/extra-params.constants.ts
+++ b/src/app/charts/extra-params-components/extra-params.constants.ts
@@ -54,11 +54,6 @@ export function isThresholdIndicator(indicatorName: string): boolean {
     return thresholdIndicatorNames.indexOf(indicatorName) !== -1;
 }
 
-// TODO: use or remove this function
-export function hasExtraParams(indicatorName: string): boolean {
-    return extraParamsIndicatorNames.indexOf(indicatorName) !== -1;
-}
-
 export function isPercentileIndicator(indicatorName: string): boolean {
     return percentileIndicatorNames.indexOf(indicatorName) !== -1;
 }

--- a/src/app/charts/extra-params-components/threshold.component.ts
+++ b/src/app/charts/extra-params-components/threshold.component.ts
@@ -37,7 +37,7 @@ export class ThresholdComponent implements AfterViewInit, OnInit {
     // default form values
     private defaultThreshold = 50;
     private defaultUnit = '';
-    private defaultPrecipitationUnit = 'mm';
+    private defaultPrecipitationUnit = 'mm/day';
     private defaultTemperatureUnit = 'F';
     private defaultComparator = 'lte';
 


### PR DESCRIPTION
## Overview

Update query units used by precipitation threshold chart to match API, which now uses rates.


### Demo

![precip_units](https://user-images.githubusercontent.com/960264/31352523-0ffce12e-acfd-11e7-86bb-1b4c8452bf7b.png)


### Notes

Existing lab projects with a precipitation threshold chart selected will remain broken until the chart or query unit selection gets updated.


## Testing Instructions

 * Select precipitation threshold indicator from sidebar
 * Chart should load with any of the three query unit options


Closes #276 

