### PR TITLE
Add LOCA legend and show when choice is active

### DIFF
--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -61,7 +61,8 @@
             </div>
         </div>
         <div class="chart-legend">
-            <span>Derived from the NASA Earth Exchange Global Daily Downscaled Projections (NEX-GDDP) dataset.</span>
+            <span *ngIf="dataset.name === 'NEX-GDDP'">Derived from the NASA Earth Exchange Global Daily Downscaled Projections (NEX-GDDP) dataset.</span>
+            <span *ngIf="dataset.name === 'LOCA'">Downscaled from CMIP5, using the Localized Constructed Analogs (LOCA) statistical technique. Data available at <a href="http://loca.ucsd.edu">loca.ucsd.edu</a>.</span>
         </div>
         <div class="chart-options buttons">
             <div class="chart-options-body">

--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -35,6 +35,9 @@ ccl-chart {
 
   .noUi-pips-horizontal {
     font-size: 12px;
+    // Prevents this div from creating an area outside the pips that can't be clicked on
+    // Setting height to zero doesn't seem to affect any part of the visible page layout
+    height: 0;
   }
 
   .noUi-marker-horizontal.noUi-marker-large {


### PR DESCRIPTION
## Overview

Updates legend depending on dataset selected.


### Demo

![screen shot 2017-10-17 at 09 51 40](https://user-images.githubusercontent.com/1818302/31668663-ce18593a-b320-11e7-90fe-c9541fe35eee.png)

### Notes

LOCA link was unclickable. See comment in diff for fix, which seemed ok to make.

Text approved separately by @jcahail 

## Testing Instructions

 * Toggle LOCA and GDDP dataset options, you should see the legend change appropriately.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Closes #285 
