### PR TITLE
Remove ProjectData dependencies from Lab Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "d3-tip": "^0.7.1",
     "file-saver": "^1.3.3",
     "jquery": "^3.2.1",
-    "lodash": "^4.17.4",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.18.1",
     "ng2-nouislider": "^1.6.2",
     "ngx-bootstrap": "^1.9.1",

--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -27,7 +27,7 @@ import { isBasetempIndicator,
          isPercentileIndicator,
          isThresholdIndicator } from 'climate-change-components';
 
-import * as _ from 'lodash';
+import * as cloneDeep from 'lodash.clonedeep';
 
 /*
  * Chart component
@@ -124,14 +124,14 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
         this.chartData = [];
         this.rawChartData = [];
 
-        let params: IndicatorQueryParams = {
-            climateModels: _.filter(this.models, model => model.enabled),
+        const params: IndicatorQueryParams = {
+            climateModels: this.models.filter(model => model.enabled),
             dataset: this.dataset.name,
             unit: this.unit || this.chart.indicator.default_units,
             time_aggregation: TimeAggParam.Yearly
         }
 
-        params = _.extend(params, this.extraParams);
+        Object.assign(params, this.extraParams);
 
         const queryOpts: IndicatorRequestOpts = {
             indicator: this.chart.indicator,
@@ -153,7 +153,7 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
             delete data[1].url; // apart from URL, returned data is raw query response
             this.rawChartData = data[1];
             this.processedData = this.chartService.convertChartData(data);
-            this.chartData = _.cloneDeep(this.processedData);
+            this.chartData = cloneDeep(this.processedData);
 
             this.curlCommandHistorical = `curl -i "${chartQueryHistorical}" -H "Authorization: Token ` +
                                `${this.authService.getToken()}"`;
@@ -163,12 +163,12 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
     }
 
     sliceChartData() {
-        this.chartData = _.cloneDeep(this.processedData); // to trigger change detection
+        this.chartData = cloneDeep(this.processedData); // to trigger change detection
         const startYear = this.dateRange[0];
         const endYear = this.dateRange[1];
-        this.chartData[0]['data'] = (this.chartData[0]['data']).filter(obj => {
-            const year = obj['date'].getFullYear()
-            return year >= startYear && year <= endYear
+        this.chartData[0]['data'] = this.chartData[0]['data'].filter(obj => {
+            const year = obj['date'].getFullYear();
+            return year >= startYear && year <= endYear;
         });
     }
 

--- a/src/app/charts/extra-params-components/basetemp.component.ts
+++ b/src/app/charts/extra-params-components/basetemp.component.ts
@@ -3,8 +3,6 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { BasetempIndicatorQueryParams, Indicator, TemperatureUnits } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*
  * Basetemp params component
  * Multi-field form to allow user to specify the basetemp params

--- a/src/app/charts/extra-params-components/historic.component.ts
+++ b/src/app/charts/extra-params-components/historic.component.ts
@@ -3,8 +3,6 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 
 import { HistoricRange, HistoricIndicatorQueryParams, HistoricRangeService, Indicator } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*
  * Historic range params component
  * Form to allow user to specify the historic range base year param
@@ -56,7 +54,7 @@ export class HistoricComponent implements AfterViewInit, OnInit {
 
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
-            this.historicRangeOptions = _.map(data, 'start_year');
+            this.historicRangeOptions = data.map(h => h.start_year);
             // add empty option, as this is not a required parameter
             this.historicRangeOptions.unshift('');
         });

--- a/src/app/charts/extra-params-components/percentile.component.ts
+++ b/src/app/charts/extra-params-components/percentile.component.ts
@@ -3,8 +3,6 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { Indicator, PercentileIndicatorQueryParams } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*
  * Percentile params component
  * Uni-field form to allow user to specify the percentile params

--- a/src/app/charts/extra-params-components/threshold.component.ts
+++ b/src/app/charts/extra-params-components/threshold.component.ts
@@ -5,8 +5,6 @@ import { Indicator, ThresholdIndicatorQueryParams } from 'climate-change-compone
 import { PrecipitationUnits,
          TemperatureUnits } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*
  * Threshold params component
  * Multi-field form to allow user to specify threshold params

--- a/src/app/charts/line-graph.component.ts
+++ b/src/app/charts/line-graph.component.ts
@@ -8,9 +8,9 @@ import {
     AfterContentInit
 } from '@angular/core';
 
-import { ChartData, DataPoint, Indicator } from 'climate-change-components';
+import { ChartData, DataPoint, Indicator, MultiDataPoint } from 'climate-change-components';
 import * as D3 from 'd3';
-import * as _ from 'lodash';
+import * as cloneDeep from 'lodash.clonedeep';
 import * as $ from 'jquery';
 
 import { ChartService } from 'climate-change-components';
@@ -32,7 +32,7 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
     @Input() public hover: Boolean;
     @Input() public unit: string;
 
-    public extractedData: Array<DataPoint>;
+    public extractedData: Array<MultiDataPoint>;
 
     private host;                          // D3 object referebcing host dom object
     private svg;                           // SVG in which we will print our chart
@@ -102,8 +102,11 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
 
     private filterData(): void {
         // Preserves parent data by fresh copying indicator data that will undergo processing
-        _.has(this.data[0], 'data') ?
-            this.extractedData = _.cloneDeep(this.data[0]['data']) : this.extractedData = [];
+        if (this.data && this.data[0] && this.data[0].data) {
+            this.extractedData = cloneDeep(this.data[0]['data']);
+        } else {
+            this.extractedData = [];
+        }
         // Remove empty day in non-leap years (affects only daily data)
         if (this.extractedData[365] && this.extractedData[365]['date'] == null) {
             this.extractedData.pop();
@@ -137,14 +140,14 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
         // Sort data by date ascending
         this.extractedData.sort(function(a, b) { return +a.date - +b.date; });
         // Parse out avg data for ease of use later
-        this.yData = _.map(this.extractedData, d => d.values.avg);
+        this.yData = this.extractedData.map(d => d.values.avg);
 
         this.xRange = D3.extent(this.extractedData, d => d.date);
         this.xScale.domain(this.xRange);
 
         // Adjust y scale, prettify graph
-        const minY = D3.min(_.map(this.extractedData, d => d.values.min));
-        const maxY = D3.max(_.map(this.extractedData, d => d.values.max));
+        const minY = D3.min(this.extractedData.map(d => d.values.min));
+        const maxY = D3.max(this.extractedData.map(d => d.values.max));
         // Note: 5 as default is arbitrary
         const yPad = (maxY - minY) > 0 ? (maxY - minY) * 1 / 3 : 5;
         // if minY is 0, keep it that way
@@ -206,7 +209,7 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
 
     /* Draw line */
     private drawAvgLine(): void {
-        const data = _.map(this.extractedData, d => ({'date': d.date, 'value': d.values.avg }));
+        const data = this.extractedData.map(d => ({'date': d.date, 'value': d.values.avg }));
         this.drawLine(data, 'line');
     }
 
@@ -216,9 +219,9 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
             .y0(d => this.yScale(d.min))
             .y1(d => this.yScale(d.max));
 
-        const minMaxData = _.map(this.extractedData, d => ({'date': d.date,
-                                                          'min': d.values.min,
-                                                          'max': d.values.max}));
+        const minMaxData = this.extractedData.map(d => ({'date': d.date,
+                                                         'min': d.values.min,
+                                                         'max': d.values.max}));
 
         // Draw min/max area
         this.svg.append('path')

--- a/src/app/lab/components/dataset-toggle.component.html
+++ b/src/app/lab/components/dataset-toggle.component.html
@@ -1,0 +1,9 @@
+<div class="dropdown button-group">
+  <button class="button"
+          *ngFor="let s of datasets"
+          [disabled]="!checkValidDataset(s)"
+          [ngClass]="{'active': s.name === dataset.name}"
+          (click)="onDatasetClicked(s, $event)">
+    {{ s.name }}
+  </button>
+</div>

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -2,8 +2,6 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { City, ClimateModel, Dataset, DatasetService } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*  Dataset Toggle Component
 
     -- Requires project input
@@ -40,7 +38,7 @@ export class DatasetToggleComponent implements OnInit {
         }
         this.dataset = dataset;
         this.models.forEach(model => {
-            model.enabled = _.includes(dataset.models, model.name);
+            model.enabled = dataset.models.includes(model.name);
         });
 
         if (event) {
@@ -78,7 +76,7 @@ export class DatasetToggleComponent implements OnInit {
         if (!this.city.properties) {
             return true; // city properties may be undefined in form to create new project
         }
-        return _.includes(this.city.properties.datasets, dataset.name);
+        return this.city.properties.datasets.includes(dataset.name);
     }
 
     private getDatasets() {

--- a/src/app/lab/components/dataset-toggle.component.ts
+++ b/src/app/lab/components/dataset-toggle.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
-import { Dataset, DatasetService } from 'climate-change-components';
-import { ProjectData } from '../../models/project-data.model';
+import { City, ClimateModel, Dataset, DatasetService } from 'climate-change-components';
 
 import * as _ from 'lodash';
 
@@ -10,27 +9,22 @@ import * as _ from 'lodash';
     -- Requires project input
     Expected use:
         <ccl-dataset-toggle
-            [projectData]="your_project.project_data">
+            [city]="selectedCity"
+            [dataset]="yourDataset"
+            [models]="selectedModels"
+            (onDatasetSelected)="datasetSelected($event)">
 */
 
 @Component({
   selector: 'ccl-dataset-toggle',
-  template: `
-    <div class="dropdown button-group">
-        <button class="button"
-               *ngFor="let s of datasets"
-               [disabled]="!checkValidDataset(s)"
-               [ngClass]="{'active': s.name === projectData.dataset.name}"
-               (click)="onDatasetSelected(s, $event)">
-            {{ s.name }}
-        </button>
-    </div>
-  `
-
+  templateUrl: './dataset-toggle.component.html'
 })
 export class DatasetToggleComponent implements OnInit {
 
-    @Input() projectData: ProjectData;
+    @Input() city: City;
+    @Input() dataset: Dataset;
+    @Input() models: ClimateModel[];
+    @Output() onDatasetSelected = new EventEmitter<Dataset>();
     public datasets: Dataset[] = [];
     private DEFAULT_DATASET_NAME = 'NEX-GDDP';
 
@@ -40,18 +34,19 @@ export class DatasetToggleComponent implements OnInit {
         this.getDatasets();
     }
 
-    public onDatasetSelected(dataset: Dataset, event?: Event) {
+    public onDatasetClicked(dataset: Dataset, event?: Event) {
         if (!this.isValidDataset(dataset)) {
             this.selectDefaultDataset();
         }
-        this.projectData.dataset = dataset;
-        this.projectData.models.forEach(model => {
+        this.dataset = dataset;
+        this.models.forEach(model => {
             model.enabled = _.includes(dataset.models, model.name);
         });
 
         if (event) {
             event.preventDefault();
         }
+        this.onDatasetSelected.emit(dataset);
     }
 
     // set to default, or first valid option for the selected city
@@ -63,14 +58,14 @@ export class DatasetToggleComponent implements OnInit {
             dataset = this.datasets.find(s => this.isValidDataset(s));
         }
 
-        this.onDatasetSelected(dataset);
+        this.onDatasetClicked(dataset);
     }
 
     // check if a given dataset is valid and change it if not and it is selected
     public checkValidDataset(dataset: Dataset): boolean {
         const isValid = this.isValidDataset(dataset);
-        if (!isValid && this.projectData.dataset &&
-            this.projectData.dataset.name === dataset.name) {
+        if (!isValid && this.dataset &&
+            this.dataset.name === dataset.name) {
             // If this dataset is selected but not valid, change to a valid dataset.
             // Do so within a timeout to avoid change detection errors.
             setTimeout(() => this.selectDefaultDataset());
@@ -80,10 +75,10 @@ export class DatasetToggleComponent implements OnInit {
 
     // helper that checks if a given dataset is available for the currently selected city
     public isValidDataset(dataset: Dataset): boolean {
-        if (!this.projectData.city.properties) {
+        if (!this.city.properties) {
             return true; // city properties may be undefined in form to create new project
         }
-        return _.includes(this.projectData.city.properties.datasets, dataset.name);
+        return _.includes(this.city.properties.datasets, dataset.name);
     }
 
     private getDatasets() {
@@ -91,7 +86,7 @@ export class DatasetToggleComponent implements OnInit {
             this.datasets = data;
 
             // Set a default for the project if none is set
-            if (!this.projectData.dataset) {
+            if (!this.dataset) {
                 this.selectDefaultDataset();
             }
         });

--- a/src/app/lab/components/model-modal.component.ts
+++ b/src/app/lab/components/model-modal.component.ts
@@ -4,8 +4,6 @@ import {} from ''
 
 import { ClimateModel, ClimateModelService, Dataset } from 'climate-change-components';
 
-import * as _ from 'lodash';
-
 /*  Model Modal Component
     -- Requires input for selected dataset and models
     -- Emits selected model
@@ -47,7 +45,7 @@ export class ModelModalComponent implements OnInit {
             return;
         }
         this.climateModels.forEach(model => {
-            model.enabled = _.includes(this.dataset.models, model.name);
+            model.enabled = this.dataset.models.includes(model.name);
         });
     }
 

--- a/src/app/lab/components/scenario-toggle.component.html
+++ b/src/app/lab/components/scenario-toggle.component.html
@@ -1,0 +1,8 @@
+<div class="dropdown button-group">
+  <button class="button"
+          *ngFor="let s of scenarios"
+          [ngClass]="{'active': s.name === scenario.name}"
+          (click)="onScenarioClicked(s, $event)">
+    {{ s.label }}
+  </button>
+</div>

--- a/src/app/lab/components/scenario-toggle.component.ts
+++ b/src/app/lab/components/scenario-toggle.component.ts
@@ -7,7 +7,7 @@ import { Scenario, ScenarioService } from 'climate-change-components';
     -- Requires project input
     Expected use:
         <ccl-scenario-toggle
-            [projectData]="your_project.project_data">
+            [scenario]="yourScenario">
 */
 
 @Component({

--- a/src/app/lab/components/scenario-toggle.component.ts
+++ b/src/app/lab/components/scenario-toggle.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 
 import { Scenario, ScenarioService } from 'climate-change-components';
-import { ProjectData } from '../../models/project-data.model';
 
 /*  Scenario Toggle Component
 
@@ -13,21 +12,12 @@ import { ProjectData } from '../../models/project-data.model';
 
 @Component({
   selector: 'ccl-scenario-toggle',
-  template: `
-    <div class="dropdown button-group">
-        <button class="button"
-               *ngFor="let s of scenarios"
-               [ngClass]="{'active': s.name === projectData.scenario.name}"
-               (click)="onScenarioClicked(s, $event)">
-            {{ s.label }}
-        </button>
-    </div>
-  `
-
+  templateUrl: './scenario-toggle.component.html'
 })
 export class ScenarioToggleComponent implements OnInit {
 
-    @Input() projectData: ProjectData;
+    @Input() scenario: Scenario;
+    @Output() onScenarioSelected = new EventEmitter<Scenario>();
     public scenarios: Scenario[] = [];
     private DEFAULT_SCENARIO_NAME = 'RCP85';
     private VALID_SCENARIOS = ['RCP85', 'RCP45'];
@@ -39,10 +29,11 @@ export class ScenarioToggleComponent implements OnInit {
     }
 
     public onScenarioClicked(scenario: Scenario, event?: Event) {
-        this.projectData.scenario = scenario;
+        this.scenario = scenario;
         if (event) {
             event.preventDefault();
         }
+        this.onScenarioSelected.emit(scenario);
     }
 
     private getScenarios() {
@@ -50,7 +41,7 @@ export class ScenarioToggleComponent implements OnInit {
             this.scenarios = data.filter(s => this.VALID_SCENARIOS.includes(s.name));
 
             // Set a default for the project if none is set
-            if (!this.projectData.scenario.label) {
+            if (!this.scenario.label) {
                 this.onScenarioClicked(this.scenarios.find((s) => {
                     return s.name === this.DEFAULT_SCENARIO_NAME;
                 }));

--- a/src/app/lab/components/units-dropdown.component.html
+++ b/src/app/lab/components/units-dropdown.component.html
@@ -1,0 +1,18 @@
+<div dropdown class="dropdown dropdown-units">
+  <button
+      dropdownToggle
+      class="button dropdown-toggle"
+      id="unitsDropdown"
+      type="button"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="true">
+    {{ unit || 'N/A' }}
+    <i class="caret"></i>
+  </button>
+  <ul *dropdownMenu class="dropdown-menu" aria-labelledby="unitsDropdown">
+    <li *ngFor="let unit of units">
+      <a (click)="onUnitSelected(unit)" placement="bottom">{{ unit }}</a>
+    </li>
+  </ul>
+</div>

--- a/src/app/lab/components/units-dropdown.component.ts
+++ b/src/app/lab/components/units-dropdown.component.ts
@@ -12,22 +12,8 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'ccl-units-dropdown',
-  template: `<div dropdown class="dropdown dropdown-units">
-              <button dropdownToggle class="button dropdown-toggle" type="button"
-                id="unitsDropdown" data-toggle="dropdown" aria-haspopup="true"
-                aria-expanded="true">
-                {{ unit || 'N/A' }}
-                <i class="caret"></i>
-              </button>
-              <ul *dropdownMenu class="dropdown-menu" aria-labelledby="unitsDropdown">
-                <li *ngFor="let unit of units">
-                  <a (click)="onUnitSelected(unit)"
-                    placement="bottom">{{ unit }}</a>
-                </li>
-              </ul>
-            </div>`
+  templateUrl: './units-dropdown.component.html'
 })
-
 export class UnitsDropdownComponent {
 
     @Input() units: [string];

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -17,7 +17,10 @@
             <!-- scenario selector -->
             <div class="control-group">
               <label>Scenario</label>
-              <ccl-scenario-toggle [projectData]="project.project_data"></ccl-scenario-toggle>
+              <ccl-scenario-toggle
+                [scenario]="project.project_data.scenario"
+                (onScenarioSelected)="scenarioSelected($event)">
+              </ccl-scenario-toggle>
             </div>
             <!-- dataset selector -->
             <div class="control-group">

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -25,7 +25,11 @@
             <!-- dataset selector -->
             <div class="control-group">
               <label>Dataset</label>
-              <ccl-dataset-toggle [projectData]="project.project_data"></ccl-dataset-toggle>
+              <ccl-dataset-toggle [city]="project.project_data.city"
+                                  [dataset]="project.project_data.dataset"
+                                  [models]="project.project_data.models"
+                                  (onDatasetSelected)="datasetSelected($event)">
+              </ccl-dataset-toggle>
             </div>
             <!-- climate model selector -->
             <div class="control-group">

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -34,7 +34,10 @@
             <!-- climate model selector -->
             <div class="control-group">
               <label>Models</label>
-              <ccl-model-modal [projectData]="project.project_data"></ccl-model-modal>
+              <ccl-model-modal [dataset]="project.project_data.dataset"
+                               [models]="project.project_data.models"
+                               (onModelsChanged)="modelsChanged($event)">
+              </ccl-model-modal>
             </div>
             <!-- units selector, only show if indicator selected -->
             <div class="control-group">

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -10,7 +10,13 @@ import { Component,
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
-import { Chart, Indicator, IndicatorQueryParams, Scenario } from 'climate-change-components';
+import {
+    Chart,
+    Dataset,
+    Indicator,
+    IndicatorQueryParams,
+    Scenario
+} from 'climate-change-components';
 
 import { ProjectService } from '../services/project.service';
 
@@ -83,6 +89,10 @@ export class LabComponent implements OnInit, OnDestroy {
 
     public saveExtraParams(params: IndicatorQueryParams) {
         this.project.project_data.extraParams = params;
+    }
+
+    public datasetSelected(dataset: Dataset) {
+        this.project.project_data.dataset = dataset;
     }
 
     public indicatorSelected(indicator: Indicator) {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -12,6 +12,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import {
     Chart,
+    ClimateModel,
     Dataset,
     Indicator,
     IndicatorQueryParams,
@@ -113,6 +114,10 @@ export class LabComponent implements OnInit, OnDestroy {
                                      unit: indicator.default_units});
             this.project.project_data.charts = [chart];
         })
+    }
+
+    public modelsChanged(models: ClimateModel[]) {
+        this.project.project_data.models = models;
     }
 
     public scenarioSelected(scenario: Scenario) {

--- a/src/app/lab/lab.component.ts
+++ b/src/app/lab/lab.component.ts
@@ -10,7 +10,7 @@ import { Component,
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
-import { Chart, Indicator, IndicatorQueryParams } from 'climate-change-components';
+import { Chart, Indicator, IndicatorQueryParams, Scenario } from 'climate-change-components';
 
 import { ProjectService } from '../services/project.service';
 
@@ -103,5 +103,9 @@ export class LabComponent implements OnInit, OnDestroy {
                                      unit: indicator.default_units});
             this.project.project_data.charts = [chart];
         })
+    }
+
+    public scenarioSelected(scenario: Scenario) {
+        this.project.project_data.scenario = scenario;
     }
 }

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -43,7 +43,10 @@
                         </div>
                         <div class="column-4 flex-column">
                             <label for="project.models">Models</label>
-                            <ccl-model-modal [projectData]="model.project.project_data"></ccl-model-modal>
+                            <ccl-model-modal [dataset]="model.project.project_data.dataset"
+                                             [models]="model.project.project_data.models"
+                                             (onModelsChanged)="modelsChanged($event)">
+                            </ccl-model-modal>
                         </div>
                     </div>
                 </div>

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -35,7 +35,10 @@
                         <div class="column-4 flex-column">
                             <label for="project.scenario">Dataset*</label>
                             <ccl-dataset-toggle
-                                [projectData]="model.project.project_data">
+                                [city]="model.project.project_data.city"
+                                [dataset]="model.project.project_data.dataset"
+                                [models]="model.project.project_data.models"
+                                (onDatasetSelected)="datasetSelected($event)">
                             </ccl-dataset-toggle>
                         </div>
                         <div class="column-4 flex-column">

--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -27,7 +27,10 @@
                     <div class="row">
                         <div class="column-4 flex-column">
                             <label for="project.scenario">Scenario*</label>
-                            <ccl-scenario-toggle [projectData]="model.project.project_data"></ccl-scenario-toggle>
+                            <ccl-scenario-toggle
+                                [scenario]="model.project.project_data.scenario"
+                                (onScenarioSelected)="scenarioSelected($event)">
+                            </ccl-scenario-toggle>
                         </div>
                         <div class="column-4 flex-column">
                             <label for="project.scenario">Dataset*</label>

--- a/src/app/project/add-edit-project.component.ts
+++ b/src/app/project/add-edit-project.component.ts
@@ -79,4 +79,8 @@ export class AddEditProjectComponent implements OnInit {
     onSuccess() {
         this.router.navigate(['/lab', this.model.project.id]);
     }
+
+    scenarioSelected(scenario: Scenario) {
+        this.model.project.project_data.scenario = scenario;
+    }
 }

--- a/src/app/project/add-edit-project.component.ts
+++ b/src/app/project/add-edit-project.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
-import { City, Dataset, Scenario } from 'climate-change-components';
+import { City, ClimateModel, Dataset, Scenario } from 'climate-change-components';
 
 import { Project } from '../models/project.model';
 import { ProjectData } from '../models/project-data.model';
@@ -82,6 +82,10 @@ export class AddEditProjectComponent implements OnInit {
 
     datasetSelected(dataset: Dataset) {
         this.model.project.project_data.dataset = dataset;
+    }
+
+    modelsChanged(models: ClimateModel[]) {
+        this.model.project.project_data.models = models;
     }
 
     scenarioSelected(scenario: Scenario) {

--- a/src/app/project/add-edit-project.component.ts
+++ b/src/app/project/add-edit-project.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
-import { Scenario, City } from 'climate-change-components';
+import { City, Dataset, Scenario } from 'climate-change-components';
 
 import { Project } from '../models/project.model';
 import { ProjectData } from '../models/project-data.model';
@@ -78,6 +78,10 @@ export class AddEditProjectComponent implements OnInit {
 
     onSuccess() {
         this.router.navigate(['/lab', this.model.project.id]);
+    }
+
+    datasetSelected(dataset: Dataset) {
+        this.model.project.project_data.dataset = dataset;
     }
 
     scenarioSelected(scenario: Scenario) {

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -7,8 +7,6 @@ import { ProjectData } from '../models/project-data.model';
 import { LabApiHttp } from '../auth/api-http.service';
 import { apiHost } from '../constants';
 
-import * as _ from 'lodash';
-
 @Injectable()
 export class ProjectService {
 


### PR DESCRIPTION
## Overview

Part one of a two part strategy for splitting the lab components off to climate-change-components. Required removing all references to project models from the components to be moved.

### Demo

None, app should continue to work as expected

### Notes

CityDropdownComponent stays in Lab for now. It has a local dependency on ng2-autocomplete which is complicated to import, because that has a dependency on the apiHttpProvider in Lab which configures the apiHost and token auth properly. Dug a bit into this rabbit hole and bailed out for now. This is probably fine as CityDropdown isn't one of the components we immediately need, and a location search typeahead will likely be built differently in temperate and not tied to Climate API cities directly.

Since I was refactoring, theres a commit tacked onto the end that refactors most of the use of lodash out of the project, with the exception of the use of cloneDeep. Also updates the lodash dep to only be the code for the cloneDeep method, to prevent temptation to use things like `_.map` in the future when `Array.map` is valid ES6, with polyfills as appropriate handled by the underlying build process.

## Testing Instructions

Checkout, update deps with `yarn` and make sure the app works the same as before.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Connects #283 

@maurizi didn't assign you, but you might want to take a look as well.
