### PR TITLE
Add historic percentile control

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/router": "^4.4.6",
     "@types/geojson": "^1.0.3",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "^0.2.0",
+    "climate-change-components": "^0.2.1",
     "core-js": "^2.5.1",
     "d3": "^4.10.0",
     "d3-tip": "^0.7.1",

--- a/src/app/charts/chart.component.html
+++ b/src/app/charts/chart.component.html
@@ -17,14 +17,25 @@
         (basetempParamSelected)="onExtraParamsSelected($event)">
     </ccc-basetemp-parameters>
 </div>
-<div *ngIf="isPercentileIndicator(chart.indicator.name)" class="chart-options">
+<!-- both percentile and historic extra parameters -->
+<div *ngIf="isPercentileIndicator(chart.indicator.name) &&
+            isHistoricIndicator(chart.indicator.name)" class="chart-options">
+    <ccc-percentile-historic-parameters
+        [indicator]="chart.indicator"
+        [extraParams]="extraParams"
+        (percentileHistoricParamSelected)="onExtraParamsSelected($event)">
+    </ccc-percentile-historic-parameters>
+</div>
+<div *ngIf="isPercentileIndicator(chart.indicator.name) &&
+            !isHistoricIndicator(chart.indicator.name)" class="chart-options">
     <ccc-percentile-parameters
         [indicator]="chart.indicator"
         [extraParams]="extraParams"
         (percentileParamSelected)="onExtraParamsSelected($event)">
     </ccc-percentile-parameters>
 </div>
-<div *ngIf="isHistoricIndicator(chart.indicator.name)" class="chart-options">
+<div *ngIf="isHistoricIndicator(chart.indicator.name) &&
+            !isPercentileIndicator(chart.indicator.name)" class="chart-options">
     <ccc-historic-parameters
         [indicator]="chart.indicator"
         [extraParams]="extraParams"

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,9 +896,9 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-climate-change-components@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.0.tgz#ba2534e1e36d320d9524db47a70a4e26a73dde70"
+climate-change-components@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.1.tgz#6538d68af9dd176805469f327f4a565eb394b6ef"
   dependencies:
     "@angular/animations" "^4.3.6"
     "@angular/common" "^4.3.6"


### PR DESCRIPTION
## Overview

For controlling both historic range and percentile extra query parameters.
Depends on a change to the `climate-change-components` library to add the QueryParams.


### Demo

![percentile_historic](https://user-images.githubusercontent.com/960264/32392554-8649953a-c0ac-11e7-90f0-36d77e33efdf.png)


## Testing Instructions

 * Check out branch in azavea/climate-change-components#9
 * In components project directory: `yarn run build:library && npm pack`
 * In this project/branch: `yarn install`
 * `npm install ../climate-change-components/climate-change-components-0.2.1.tgz`
 * `yarn serve`
 * Load Extreme Precipitation Events chart
 * Chart should load, and update on changes to either control

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Closes #247
