### PR TITLE
Fix styling issue cut-off select contents in charts

### DIFF
--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -198,9 +198,8 @@ ccl-chart {
         font-weight: $body-font-weight;
         font-family: $body-font-family;
         margin-right: 0.5rem;
-        height: 30px;
         min-width: 100px;
-        padding: 1rem 0;
+        padding: 0;
 
         font-size: 14px;
         text-align: left;


### PR DESCRIPTION
## Overview

Fixes styling issues with `<select>` elements.

### Screenshot
![localhost-4200-](https://user-images.githubusercontent.com/4432106/32518601-17932bcc-c3d8-11e7-9503-99ef58bb1713.png)


### Notes

I tested on Firefox & Chrome on Ubuntu, as well as Edge on Windows. It would be a good idea to double-check this on Safari.

## Testing Instructions

 * Verify that dropdowns look correct on the "Precipitation Threshold" component

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Fixes #234
