### PR TITLE
Fix chart display on Safari

### DIFF
--- a/src/assets/sass/components/_chart.scss
+++ b/src/assets/sass/components/_chart.scss
@@ -1,13 +1,19 @@
 .chart {
   height: 100%;
-  display: flex;
-  flex-direction: column;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
 }
 
 .chart-graphic {
   height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
+  position: absolute;
+  top: 0;
+  bottom: 0;
 }
 
 ccc-line-graph {
@@ -24,6 +30,8 @@ ccc-line-graph {
 
 .chart-container {
   height: 100%;
+  flex: 1;
+  position: relative;
 }
 
 ccl-chart {
@@ -99,7 +107,9 @@ ccl-chart {
   }
 
   .chart-body {
-    flex: 1;
+    flex: 1 0  auto;
+    width: 100%;
+    position: relative;
   }
 
   .chart-options {


### PR DESCRIPTION
## Overview

Charts were not appearing because the flexbox-based layout was giving the chart and some of its child elements 0 height.

Switching to absolutely positioned elements for some items seems to be be more well supported, and did not seem to cause any regressions on other browsers.

## Testing Instructions

 * `yarn run serve`
 * Charts should be properly sized and visible on all supported browsers

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Fixes #244
Fixes #304