### PR TITLE
Use Node 6 instead of Node 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./
       dockerfile: Dockerfile
       args:
-        NODE_VERSION: "7.10-slim"
+        NODE_VERSION: "6-slim"
     working_dir: /opt/app
     environment:
       - CHROME_BIN=/usr/bin/chromium


### PR DESCRIPTION
## Overview

Switches the project to build using Node 6, which is an LTS release.

## Testing
 - Does the Jenkins build pass?

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Closes #291
