### PR TITLE
Feature/al/chart height

### DIFF
--- a/src/assets/sass/layout/_content.scss
+++ b/src/assets/sass/layout/_content.scss
@@ -1,25 +1,26 @@
 .flex-container {
   display: flex;
-  -webkit-justify-content: space-around;
-  flex-grow: 1;
-  flex-shrink: 1;
   position: relative;
+  width: 100%;
+  height: 100%;
+  flex: 1 1 auto;
+  justify-content: space-around;
+  overflow: hidden;
 }
 
 .flex-expand {
   color: #fff;
-  flex: 1;
   display: flex;
+  flex: 1;
   flex-direction: column;
   overflow: hidden;
-  flex: 1;
 }
 
 .app-fullscreen {
   display: flex;
   flex-direction: column;
-  height: 100%;
   flex: 1;
+  height: 100%;
   position: absolute;
   top: 0;
   bottom: 0;

--- a/src/assets/sass/layout/_content.scss
+++ b/src/assets/sass/layout/_content.scss
@@ -1,8 +1,6 @@
 .flex-container {
   display: flex;
   position: relative;
-  width: 100%;
-  height: 100%;
   flex: 1 1 auto;
   justify-content: space-around;
   overflow: hidden;


### PR DESCRIPTION
## Overview

The chart was not fitting to the height of the screen in Firefox. Other than introducing an inconsistency between browsers, this made its height dependent on the height of the side navigation.

### Demo (Firefox screenshots)
#### Sidebar full height (scrolls)
![screen shot 2017-11-15 at 4 13 59 pm](https://user-images.githubusercontent.com/5672295/32860610-26e3b332-ca20-11e7-9185-f24757326a9c.png)
#### Sidebar partially collapsed
![screen shot 2017-11-15 at 4 14 07 pm](https://user-images.githubusercontent.com/5672295/32860611-26f6a46a-ca20-11e7-9e11-8fd45622a95b.png)

### Notes
- Unrelated to this issue, the angular component `<ccl-sidebar>` should have its class changed from `class="sidebar-content scrollable"` to `class="sidebar"`. This will need to be addressed in a separate PR and shouldn't affect UI.
- It doesn't seem critical, but could be worthwhile to consider adding a min-height to the chart, as it gets pretty small at certain screen heights.

Closes|Fixes azavea/climate-change-components#13
