### PR TITLE
Lab tweaks for Prep Demo

### DIFF
--- a/src/app/charts/chart.component.ts
+++ b/src/app/charts/chart.component.ts
@@ -150,8 +150,7 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
         ).subscribe(data => {
             const chartQueryHistorical = data[0].url;
             const chartQueryFuture = data[1].url;
-            delete data[1].url; // apart from URL, returned data is raw query response
-            this.rawChartData = data[1];
+            this.rawChartData = data;
             this.processedData = this.chartService.convertChartData(data);
             this.chartData = cloneDeep(this.processedData);
 
@@ -173,7 +172,12 @@ export class ChartComponent implements OnChanges, OnDestroy, AfterViewInit {
     }
 
     onExportClicked() {
-        this.dataExportService.downloadAsJSON(this.rawChartData);
+        const historicalData = this.rawChartData[0];
+        const historicalFilename = `historical-${historicalData.indicator.name}.json`;
+        this.dataExportService.downloadAsJSON(historicalFilename, historicalData);
+        const futureData = this.rawChartData[1];
+        const futureFilename = `future-${futureData.indicator.name}.json`;
+        this.dataExportService.downloadAsJSON(futureFilename, futureData);
     }
 
     onDownloadImageClicked() {

--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -4,7 +4,10 @@
 
     <div class="flex-container">
 
-      <ccl-sidebar class="sidebar-content scrollable" (onIndicatorSelected)="indicatorSelected($event)"></ccl-sidebar>
+      <ccl-sidebar
+        class="sidebar-content scrollable"
+        [indicator]="indicator"
+        (onIndicatorSelected)="indicatorSelected($event)"></ccl-sidebar>
 
       <div class="flex-expand">
         <nav class="controls">

--- a/src/app/services/data-export.service.ts
+++ b/src/app/services/data-export.service.ts
@@ -8,8 +8,7 @@ import * as FileSaver from 'file-saver';
 @Injectable()
 export class DataExportService {
 
-    public downloadAsJSON(data): void {
-        const filename = data.indicator.name + '.json';
+    public downloadAsJSON(filename: string, data: any): void {
         this.downloadFile(JSON.stringify(data), filename, 'application/json');
     }
 

--- a/src/app/services/image-export.service.ts
+++ b/src/app/services/image-export.service.ts
@@ -10,11 +10,11 @@ export class ImageExportService {
 
     // options to pass when converting SVG to PNG
     private chartOptions = {
-            backgroundColor: 'white',
-            selectorRemap: function(selector) {
-                // find CSS selectors mapped to parent chart
-                return selector.replace('ccl-chart', '');
-            }
+        backgroundColor: 'white',
+        selectorRemap: function(selector) {
+            // find CSS selectors mapped to parent chart
+            return selector.replace('ccl-chart', '');
+        }
     };
 
     /**

--- a/src/app/sidebar/indicator-list.component.html
+++ b/src/app/sidebar/indicator-list.component.html
@@ -1,4 +1,6 @@
-<button class="indicator" *ngFor="let indicator of indicators"
-    (click)="onIndicatorClicked(indicator)"
-    tooltip="{{ indicator.description }}"
-    placement="right">{{indicator.label}}</button>
+<button class="indicator"
+    *ngFor="let i of indicators"
+    [ngClass]="{'active': indicator.name === i.name}"
+    (click)="onIndicatorClicked(i)"
+    tooltip="{{ i.description }}"
+    placement="right">{{i.label}}</button>

--- a/src/app/sidebar/indicator-list.component.ts
+++ b/src/app/sidebar/indicator-list.component.ts
@@ -13,6 +13,7 @@ import { Indicator } from 'climate-change-components';
 })
 export class IndicatorListComponent {
 
+    @Input() indicator: Indicator;
     @Input() indicators: Indicator[];
     @Output() indicatorClicked = new EventEmitter<Indicator>();
 

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -2,12 +2,14 @@
     <h3 class="sidebar-category" (click)="isTempCollapsed = !isTempCollapsed">Temperature</h3>
     <ccl-indicator-list
         [collapse]="isTempCollapsed"
+        [indicator]="indicator"
         [indicators]="tempIndicators"
         (indicatorClicked)="onIndicatorClicked($event)">
     </ccl-indicator-list>
     <h3 class="sidebar-category" (click)="isPrecipCollapsed = !isPrecipCollapsed">Precipitation</h3>
     <ccl-indicator-list
         [collapse]="isPrecipCollapsed"
+        [indicator]="indicator"
         [indicators]="precipIndicators"
         (indicatorClicked)="onIndicatorClicked($event)">
     </ccl-indicator-list>

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, ViewEncapsulation, OnInit, Output } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+    ViewEncapsulation
+} from '@angular/core';
 
 import { IndicatorService } from 'climate-change-components';
 import { Indicator } from 'climate-change-components';
@@ -17,6 +24,7 @@ import { isThresholdIndicator } from 'climate-change-components';
 })
 export class SidebarComponent implements OnInit {
 
+    @Input() indicator: Indicator;
     @Output() onIndicatorSelected = new EventEmitter<Indicator>();
 
     public tempIndicators: Indicator[];

--- a/src/assets/sass/components/_sidebar.scss
+++ b/src/assets/sass/components/_sidebar.scss
@@ -31,6 +31,11 @@ ccl-sidebar {
   text-align: left;
   position: relative;
   color: #4a4a4a;
+
+  &.active {
+    color: $brand-primary;
+    outline: none;
+  }
   &:hover {
     color: $brand-primary;
     cursor: pointer;


### PR DESCRIPTION
## Overview

Two small changes to the Lab in preparation for the Prep demo on Wednesday.

1. Download both the future and historical API calls when downloading JSON.
1. Highlight the currently active Indicator in the sidebar

### Demo

![screen shot 2017-11-27 at 15 03 02](https://user-images.githubusercontent.com/1818302/33286726-49ea8cb2-d384-11e7-8755-3610b93ca589.png)


## Testing Instructions

Ensure the currently active indicator is highlighted in blue both when you choose a new indicator as well as when the app initially loads.

Ensure that you get both the Historical and Future JSON files when you click the "Download JSON" button. Some browsers will require user interaction to verify that downloading multiple files is OK.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?
