### PR TITLE
Fix tslint whitespace issue in Jenkins env

### DIFF
--- a/src/app/services/image-export.service.ts
+++ b/src/app/services/image-export.service.ts
@@ -20,8 +20,8 @@ export class ImageExportService {
     /**
      * Converts chart SVG to PNG and downloads it.
      *
-     * @param indicatorName {string} Name of indicator; used for SVG selector
-     * @param fileName {string} File name for download; will be suffixed with extension
+     * @param indicatorName - Name of indicator, used for SVG selector
+     * @param fileName - File name for download, will be suffixed with extension
      */
     public downloadAsPNG(indicatorName: string, fileName: string): void {
         const filename: string = fileName + '.png';

--- a/tslint.json
+++ b/tslint.json
@@ -104,7 +104,8 @@
       "check-branch",
       "check-decl",
       "check-operator",
-      "check-separator",
+      // Removed to work around https://github.com/palantir/tslint/issues/3251
+      // "check-separator",
       "check-type"
     ],
     "directive-selector": [


### PR DESCRIPTION
## Overview

tslint throws a "missing whitespace" error in the jsdoc comment of image-export.service.ts, but only in the jenkins environment. 

This issue is tracked here: https://github.com/palantir/tslint/issues/3251 and a scan through the comments indicates a general :shrug: that its caused by some magic combination of node + npm+  yarn + typescript + tslint + tsutils and that updating to yarn 1.2+ fixes it. I attempted this upgrade in place while SSHed into Jenkins but had no luck. I might have done something wrong getting node_modules cleaned out though.

So, for now I just removed the `whitespace.check-separator` in tslint as a workaround. I'm hopeful that a separate task to update yarn in the docker container on Jenkins would address the deeper issue. ~~Edit: first attempting a yarn version upgrade on fresh Jenkins build.~~

Created #325 to more thoroughly fix the issue.

## Testing Instructions

Jenkins should now build successfully.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?
