### PR TITLE
Bump to climate-change-components@0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/router": "^4.4.6",
     "@types/geojson": "^1.0.3",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "^0.2.1",
+    "climate-change-components": "^0.2.2",
     "core-js": "^2.5.1",
     "d3": "^4.10.0",
     "d3-tip": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,9 +896,9 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-climate-change-components@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.1.tgz#6538d68af9dd176805469f327f4a565eb394b6ef"
+climate-change-components@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.2.tgz#e23109e40eac93b67c540eebd26d6b903f0c85ce"
   dependencies:
     "@angular/animations" "^4.3.6"
     "@angular/common" "^4.3.6"


### PR DESCRIPTION
## Overview

The Lab should now reflect changes introduced in climate-change-components@0.2.2

### Demo

For example, Extreme Cold Events now properly registers as a percentile + historical indicator, the percentile input is now a dropdown, and the historical range dropdown pre-populates to 1971 (the API default).

## Testing Instructions

 * `yarn install` then view app as usual

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?
