### PR TITLE
Remove imports of the form 'rxjs' and 'rxjs/Rx'

### DIFF
--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { AuthService } from './auth.service';
 

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Headers, Http, RequestOptions } from '@angular/http';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { apiHost } from '../constants';
 

--- a/src/app/ng2-auto-complete/auto-complete.directive.ts
+++ b/src/app/ng2-auto-complete/auto-complete.directive.ts
@@ -9,7 +9,6 @@ import {
   ComponentFactoryResolver,
   SimpleChanges
 } from '@angular/core';
-import 'rxjs/Rx';
 
 import { AutoCompleteComponent } from './auto-complete.component';
 

--- a/src/app/ng2-auto-complete/auto-complete.ts
+++ b/src/app/ng2-auto-complete/auto-complete.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { Response } from '@angular/http';
-import 'rxjs/Rx';
 import { LabApiHttp } from '../auth/api-http.service';
 
 /**

--- a/src/app/services/data-export.service.ts
+++ b/src/app/services/data-export.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import 'rxjs/Rx';
 import * as FileSaver from 'file-saver';
 
 /*

--- a/src/app/services/image-export.service.ts
+++ b/src/app/services/image-export.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import 'rxjs/Rx';
 import * as SaveSvg from 'save-svg-as-png';
 
 /*

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Headers, RequestOptions, Response, URLSearchParams } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { Project } from '../models/project.model';
 import { ProjectData } from '../models/project-data.model';


### PR DESCRIPTION
## Overview

According to [this issue](https://github.com/angular/angular/issues/20349#issuecomment-343638051), importing `rxjs` and `rxjs/Rx` is not recommended. Instead, for `rxjs` prior to version 6, the import should take the form `import { Observable } from 'rxjs/Observable ';`. This applies the recommended import form to all files.

### Demo

<img width="483" alt="screen shot 2019-02-21 at 10 20 59 am" src="https://user-images.githubusercontent.com/447977/53179799-70912a00-35c2-11e9-826c-da8cea08187c.png">

### Notes

The issue implies that the `'rxjs/Rx'` form is not recommended because it significantly increases bundle sizes. However, our bundle sizes remained the same before and after making this change. I noticed that `climate-change-components` also uses the old import form, so I opened https://github.com/azavea/climate-change-components/issues/49 to switch that library to the new import form as well. That may decrease the bundle size.

## Testing Instructions

 * `rg` / `ag` / `grep` for `rxjs` and confirm that none of the imports are of the form `'rxjs'` or `'rxjs/Rx'`.
 * Run the checklist commands and confirm they work.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Closes #329
