### PR TITLE
Fix race condition in displaying models modal button

### DIFF
--- a/src/app/project/add-edit-project.component.html
+++ b/src/app/project/add-edit-project.component.html
@@ -46,7 +46,8 @@
                             <label for="project.models">Models</label>
                             <ccc-model-modal [dataset]="model.project.project_data.dataset"
                                              [models]="model.project.project_data.models"
-                                             (onModelsChanged)="modelsChanged($event)">
+                                             (onModelsChanged)="modelsChanged($event)"
+                                             *ngIf="model.project.project_data.dataset">
                             </ccc-model-modal>
                         </div>
                     </div>


### PR DESCRIPTION
## Overview

Changing the timing of endpoints on the backend confirmed my hypothesis that this issue was due to a data race. If the list of models loads *after* the list of datasets, the models button loads fine, however when the order is reversed the button doesn't fully load.

This is because the models button needs to know the current dataset to know which models are available, but we first load available datasets and then set a default dataset, leaving a period of time when the dataset is unset. This only an issue on the new project page, as on the lab page there is a preconfigured dataset, which is why we can avoid a guard there.



### Demo

N/A


### Notes

By applying this diff the my local `climate-change-api` I was able to reproduce the bug consistently, and then confirm that my fix worked:
```diff
diff --git a/django/climate_change_api/climate_data/views.py b/django/climate_change_api/climate_data/views.py
index 400e762..b8a472c 100644
--- a/django/climate_change_api/climate_data/views.py
+++ b/django/climate_change_api/climate_data/views.py
@@ -296,6 +296,10 @@ class ClimateDatasetViewSet(OverridableCacheResponseMixin, viewsets.ReadOnlyMode
     ordering_fields = ('name',)
     ordering = ('name',)
 
+    def list(self, *args, **kwargs):
+        import time
+        time.sleep(2)
+        return super().list(*args, **kwargs)
 
 class ClimateModelViewSet(OverridableCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
 
@@ -321,6 +325,11 @@ class ScenarioViewSet(OverridableCacheResponseMixin, viewsets.ReadOnlyModelViewS
     ordering_fields = ('name',)
     ordering = ('name',)
 
+    def list(self, *args, **kwargs):
+        import time
+        time.sleep(2)
+        return super().list(*args, **kwargs)
+
 
 class ClimateDataMixin(object):
```


## Testing Instructions

 * Apply the diff in the notes section to your local `climate-change-api` environment
 * Confirm you can reproduce the error on the `develop` branch of this repo
 * Confirm it is fixed with the changes in this PR

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Closes #305
